### PR TITLE
Fix checkstyle violations and add hook to help prevent pushes with failing tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./gradlew check

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ To run the project you will need to have the following installed:
 
 For information about the software versions used to build this API and a complete list of it's dependencies see build.gradle
 
+While not essential, it is highly recommended to use the pre-push git hook included in this repository to ensure that all tests are passing. This can be done by running the following command:
+`$ git config core.hooksPath .githooks`
+
 ### Environment Vars
 
 If running locally for development or testing you will need to set the following environment variables

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/EndpointSecurityTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/EndpointSecurityTest.java
@@ -3,7 +3,9 @@ package uk.gov.hmcts.reform.professionalapi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
+
 import net.serenitybdd.rest.SerenityRest;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
There were some checkstyle violations in EndpointSecurityTest about the imports so I've fixed those.

I've also added a pre-push git hook which will run `gradlew check` before pushing. If the gradle build fails, the push is aborted.

To use the hook (highly recommended), run `$ git config core.hooksPath .githooks`, and make sure the pre-push script is marked as executable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
