### PR TITLE
Temporary workaround for postgres docker issue

### DIFF
--- a/charts/rd-professional-api/values.yaml
+++ b/charts/rd-professional-api/values.yaml
@@ -10,6 +10,8 @@ java:
     LOGBACK_REQUIRE_ERROR_CODE: 'false'
   image: 'https://hmcts.azurecr.io/hmcts/draft-store-service:latest'
   postgresql:
+    image:
+      tag: 10.7.0-r68
     postgresqlUsername: dbrefdata
     postgresqlPassword: dbrefdata
     postgresqlDatabase: dbrefdata


### PR DESCRIPTION
The Bitnami postgres Docker image used by the CNP Java Helm chart has made a breaking change. Until the CNP team fix the chart, this workaround pins the Bitnami image version to a known working one

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
