### PR TITLE
Fix flaky PaymentAccountRetrieveByEmailTest

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/PaymentAccountRetrieveByEmailTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/PaymentAccountRetrieveByEmailTest.java
@@ -1,7 +1,13 @@
 package uk.gov.hmcts.reform.professionalapi;
 
+import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static uk.gov.hmcts.reform.professionalapi.controller.request.PbaAccountCreationRequest.aPbaPaymentAccount;
+import static uk.gov.hmcts.reform.professionalapi.controller.request.UserCreationRequest.aUserCreationRequest;
+import static uk.gov.hmcts.reform.professionalapi.utils.OrganisationFixtures.someMinimalOrganisationRequest;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -9,17 +15,27 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import uk.gov.hmcts.reform.professionalapi.controller.request.PbaAccountCreationRequest;
+
 @RunWith(SpringRunner.class)
 @ActiveProfiles("functional")
 public class PaymentAccountRetrieveByEmailTest extends FunctionalTestSuite {
 
     @Test
     public void can_retrieve_payment_accounts_by_email() {
+        String email = randomAlphabetic(10) + "@pbasearch.test";
+        List<PbaAccountCreationRequest> pbas = Arrays.asList(aPbaPaymentAccount().pbaNumber(randomAlphabetic(10)).build());
+        professionalApiClient.createOrganisation(
+                someMinimalOrganisationRequest()
+                .pbaAccounts(pbas)
+                .superUser(aUserCreationRequest()
+                           .firstName("some-fname")
+                           .lastName("some-lname")
+                           .email(email)
+                           .build())
+                .build());
 
-        Map<String, Object> response = professionalApiClient.retrieveOrganisationDetails();
-        String responseAsString = response.toString();
-        String emailResponseSubString = responseAsString.substring((responseAsString.lastIndexOf("email=") + 6), responseAsString.lastIndexOf(".com") + 4);
-        Map<String, Object> emailResponse = professionalApiClient.retrievePaymentAccountsByEmail(emailResponseSubString);
+        Map<String, Object> emailResponse = professionalApiClient.retrievePaymentAccountsByEmail(email);
         assertThat(emailResponse).isNotEmpty();
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/client/ProfessionalApiClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/client/ProfessionalApiClient.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.asList;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
 import static uk.gov.hmcts.reform.professionalapi.controller.request.ContactInformationCreationRequest.aContactInformationCreationRequest;
 import static uk.gov.hmcts.reform.professionalapi.controller.request.DxAddressCreationRequest.dxAddressCreationRequest;
 import static uk.gov.hmcts.reform.professionalapi.controller.request.PbaAccountCreationRequest.aPbaPaymentAccount;
@@ -66,43 +67,46 @@ public class ProfessionalApiClient {
                 .asString();
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> createOrganisation(String organisationName,
                                                   String[] pbas) {
 
         List<PbaAccountCreationRequest> pbaAccounts = asList(aPbaPaymentAccount()
-                                                                     .pbaNumber(pbas[0])
-                                                                     .build(),
+                                                                .pbaNumber(pbas[0])
+                                                                .build(),
                                                              aPbaPaymentAccount()
-                                                                     .pbaNumber(pbas[1])
-                                                                     .build());
+                                                                 .pbaNumber(pbas[1])
+                                                                 .build());
 
-        OrganisationCreationRequest organisationCreationRequest = someMinimalOrganisationRequest()
-                        .name(organisationName)
-                        .sraId(randomAlphabetic(10) + "sra-id-number1")
-                        .sraRegulated(Boolean.FALSE)
-                        .companyUrl(randomAlphabetic(10) + "company-url")
-                        .companyNumber(randomAlphabetic(5) + "com")
-                        .pbaAccounts(pbaAccounts)
-                        .superUser(aUserCreationRequest()
-                                .firstName("some-fname")
-                                .lastName("some-lname")
-                                .email(randomAlphabetic(10) + "@somewhere.com")
-                                .build())
-                        .contactInformation(Arrays.asList(aContactInformationCreationRequest()
-                                .addressLine1("addressLine1")
-                                .addressLine2("addressLine2")
-                                .addressLine3("addressLine3")
-                                .country("some-country")
-                                .county("some-county")
-                                .townCity("some-town-city")
-                                .postCode("some-post-code")
-                                .dxAddress(Arrays.asList(dxAddressCreationRequest()
-                                        .dxNumber("DX 1234567890")
-                                        .dxExchange("dxExchange").build()))
+        return createOrganisation(someMinimalOrganisationRequest()
+                .name(organisationName)
+                .sraId(randomAlphabetic(10) + "sra-id-number1")
+                .sraRegulated(Boolean.FALSE)
+                .companyUrl(randomAlphabetic(10) + "company-url")
+                .companyNumber(randomAlphabetic(5) + "com")
+                .pbaAccounts(pbaAccounts)
+                .superUser(aUserCreationRequest()
+                        .firstName("some-fname")
+                        .lastName("some-lname")
+                        .email(randomAlphabetic(10) + "@somewhere.com")
+                        .build())
+                .contactInformation(Arrays.asList(aContactInformationCreationRequest()
+                        .addressLine1("addressLine1")
+                        .addressLine2("addressLine2")
+                        .addressLine3("addressLine3")
+                        .country("some-country")
+                        .county("some-county")
+                        .townCity("some-town-city")
+                        .postCode("some-post-code")
+                        .dxAddress(Arrays.asList(dxAddressCreationRequest()
+                                .dxNumber("DX 1234567890")
+                                .dxExchange("dxExchange")
                                 .build()))
-                        .build();
+                        .build()))
+                .build());
+    }
 
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> createOrganisation(OrganisationCreationRequest organisationCreationRequest) {
         Response response = withAuthenticatedRequest()
                 .body(organisationCreationRequest)
                 .post("v1/organisations")
@@ -119,6 +123,7 @@ public class ProfessionalApiClient {
         return response.body().as(Map.class);
     }
 
+    @SuppressWarnings("unchecked")
     public Map<String, Object> retrieveOrganisationDetails() {
         Response response = withAuthenticatedRequest()
                 .body("")
@@ -137,6 +142,7 @@ public class ProfessionalApiClient {
 
     }
 
+    @SuppressWarnings("unchecked")
     public Map<String, Object> retrievePaymentAccountsByEmail(String email) {
         Response response = withAuthenticatedRequest()
                 .body("")
@@ -152,7 +158,6 @@ public class ProfessionalApiClient {
                 .statusCode(OK.value());
 
         return response.body().as(Map.class);
-
     }
 
 
@@ -160,8 +165,8 @@ public class ProfessionalApiClient {
         return RestAssured.given()
                 .relaxedHTTPSValidation()
                 .baseUri(professionalApiUrl)
-                .header("Content-Type", "application/json")
-                .header("Accepts", "application/json");
+                .header("Content-Type", APPLICATION_JSON_UTF8_VALUE)
+                .header("Accepts", APPLICATION_JSON_UTF8_VALUE);
     }
 
     private RequestSpecification withAuthenticatedRequest() {


### PR DESCRIPTION
This test assumes that the first organisation returned by a GET to /v1/organisations will have a payment account associated with the super user. This isn't always the case (as seen in this build https://build.platform.hmcts.net/job/HMCTS_RD/job/rd-professional-api/job/PR-35/1/) and functional tests **SHOULD ALWAYS** ensure the data they need is there in the database rather than relying on state.

https://tools.hmcts.net/jira/browse/RDCC-194

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
