### PR TITLE
RDCC-496 changed functional and integration tests to reflect requirement

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationTest.java
@@ -88,17 +88,17 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_False() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin, "False", HttpStatus.OK));
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin, "False", HttpStatus.OK), null);
     }
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_True() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"True", HttpStatus.OK));
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"True", HttpStatus.OK), null);
     }
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_invalid() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"invalid", HttpStatus.OK));
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"invalid", HttpStatus.OK), null);
     }
 
     @Test
@@ -114,45 +114,27 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
     }
 
     @Test
-    public void ac1_find_all_active_users_without_roles_for_an_organisation_with_non_pui_user_manager_role_should_return_200() {
+    public void ac1_find_all_active_users_with_roles_for_an_organisation_with_non_pui_user_manager_role_should_return_200() {
         Map<String, Object> response = professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.OK, generateBearerTokenForNonPuiManager(), "Active");
-        assertThat(response.get("users")).asList().isNotEmpty();
-        List<HashMap> professionalUsersResponses = (List<HashMap>) response.get("users");
-        HashMap professionalUsersResponse = professionalUsersResponses.get(0);
-        assertThat(professionalUsersResponse.get("idamStatus")).isEqualTo(IdamStatus.ACTIVE.toString());
-        validateRetrievedUsers(response);
+        validateRetrievedUsers(response, "ACTIVE");
     }
 
     @Test
-    public void ac2_find_all_status_users_without_roles_for_an_organisation_with_non_pui_user_manager_role_should_return_400() {
-        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForNonPuiManager(), " ");
-    }
-
-    @Test
-    public void ac2_1_should_return_200_and_active_users_with_roles_for_an_organisation_with_non_pui_user_manager_role_when_no_status_provided() {
-        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.OK, generateBearerTokenForNonPuiManager(), "");
-    }
-
-    @Test
-    public void ac2_2_find_pending_users_without_roles_for_an_organisation_with_non_pui_user_manager_role_should_return_400() {
-        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForNonPuiManager(), "Pending");
-    }
-
-    @Test
-    public void ac2_3_find_suspended_users_without_roles_for_an_organisation_with_non_pui_user_manager_role_should_return_400() {
-        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForNonPuiManager(), "Suspended");
+    public void ac2_should_return_200_and_active_users_with_roles_for_an_organisation_with_non_pui_user_manager_role_when_no_status_provided() {
+        Map<String, Object> response = professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.OK, generateBearerTokenForNonPuiManager(), "");
+        validateRetrievedUsers(response, "ACTIVE");
     }
 
     @Test
     public void ac3_find_all_status_users_for_an_organisation_with_pui_user_manager_should_return_200() {
         Map<String, Object> response = professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.OK, generateBearerTokenForPuiManager(), "");
-        validateRetrievedUsers(response);
+        validateRetrievedUsers(response, "any");
     }
 
     @Test
     public void ac4_find_all_active_users_for_an_organisation_with_pui_user_manager_should_return_200() {
         Map<String, Object> response = professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.OK, generateBearerTokenForPuiManager(), "Active");
-        validateRetrievedUsers(response);
+        validateRetrievedUsers(response, "ACTIVE");
     }
 
     @Test
@@ -161,7 +143,7 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
     }
 
     @Test
-    public void ac5_2_find_all_deleted_users_for_an_organisation_with_pui_user_manager_when_no_deleted_user_exists_should_return_404() {
+    public void ac5_1_find_all_deleted_users_for_an_organisation_with_pui_user_manager_when_no_deleted_user_exists_should_return_404() {
         professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.NOT_FOUND, generateBearerTokenForPuiManager(), "Deleted");
     }
 
@@ -189,26 +171,28 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
     }
 
     @Test
-    public void ac9_find_all_status_users_for_an_organisation_with_non_pui_user_manager_where_status_is_not_active_should_return_400() {
-        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForNonPuiManager(), "");
+    public void ac9_find_non_active_status_users_for_an_organisation_with_non_pui_user_manager_where_status_is_not_active_should_return_400() {
+        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForNonPuiManager(), "INVALID");
     }
 
-    void validateRetrievedUsers(Map<String, Object> searchResponse) {
+    void validateRetrievedUsers(Map<String, Object> searchResponse, String expectedStatus) {
         assertThat(searchResponse.get("users")).asList().isNotEmpty();
 
         List<HashMap> professionalUsersResponses = (List<HashMap>) searchResponse.get("users");
-        HashMap professionalUsersResponse = professionalUsersResponses.get(0);
 
         professionalUsersResponses.stream().forEach(user -> {
-            assertThat(professionalUsersResponse.get("idamStatus")).isNotNull();
-            assertThat(professionalUsersResponse.get("userIdentifier")).isNotNull();
-            assertThat(professionalUsersResponse.get("firstName")).isNotNull();
-            assertThat(professionalUsersResponse.get("lastName")).isNotNull();
-            assertThat(professionalUsersResponse.get("email")).isNotNull();
-            if (professionalUsersResponse.get("idamStatus").equals(IdamStatus.ACTIVE.toString())) {
-                assertThat(professionalUsersResponse.get("roles")).isNotNull();
+            assertThat(user.get("idamStatus")).isNotNull();
+            assertThat(user.get("userIdentifier")).isNotNull();
+            assertThat(user.get("firstName")).isNotNull();
+            assertThat(user.get("lastName")).isNotNull();
+            assertThat(user.get("email")).isNotNull();
+            if (!expectedStatus.equals("any")) {
+                assertThat(user.get("idamStatus").equals(expectedStatus));
+            }
+            if (user.get("idamStatus").equals(IdamStatus.ACTIVE.toString())) {
+                assertThat(user.get("roles")).isNotNull();
             } else {
-                assertThat(professionalUsersResponse.get("roles")).isNull();
+                assertThat(user.get("roles")).isNull();
             }
         });
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationTest.java
@@ -88,17 +88,17 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_False() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin, "False", HttpStatus.OK), null);
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin, "False", HttpStatus.OK), "any");
     }
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_True() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"True", HttpStatus.OK), null);
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"True", HttpStatus.OK), "any");
     }
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_invalid() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"invalid", HttpStatus.OK), null);
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"invalid", HttpStatus.OK), "any");
     }
 
     @Test
@@ -143,7 +143,7 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
     }
 
     @Test
-    public void ac5_1_find_all_deleted_users_for_an_organisation_with_pui_user_manager_when_no_deleted_user_exists_should_return_404() {
+    public void ac5_1_find_all_deleted_users_for_an_organisation_with_pui_user_manager_when_no_deleted_user_exists_should_return_40() {
         professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.NOT_FOUND, generateBearerTokenForPuiManager(), "Deleted");
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationTest.java
@@ -88,17 +88,17 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_False() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin, "False", HttpStatus.OK), false);
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin, "False", HttpStatus.OK));
     }
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_True() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"True", HttpStatus.OK), false);
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"True", HttpStatus.OK));
     }
 
     @Test
     public void find_users_by_active_organisation_with_showDeleted_invalid() {
-        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"invalid", HttpStatus.OK), false);
+        validateRetrievedUsers(professionalApiClient.searchUsersByOrganisation(createAndUpdateOrganisationToActive(hmctsAdmin), hmctsAdmin,"invalid", HttpStatus.OK));
     }
 
     @Test
@@ -120,7 +120,7 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
         List<HashMap> professionalUsersResponses = (List<HashMap>) response.get("users");
         HashMap professionalUsersResponse = professionalUsersResponses.get(0);
         assertThat(professionalUsersResponse.get("idamStatus")).isEqualTo(IdamStatus.ACTIVE.toString());
-        validateRetrievedUsers(response, false);
+        validateRetrievedUsers(response);
     }
 
     @Test
@@ -129,15 +129,30 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
     }
 
     @Test
+    public void ac2_1_should_return_200_and_active_users_with_roles_for_an_organisation_with_non_pui_user_manager_role_when_no_status_provided() {
+        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.OK, generateBearerTokenForNonPuiManager(), "");
+    }
+
+    @Test
+    public void ac2_2_find_pending_users_without_roles_for_an_organisation_with_non_pui_user_manager_role_should_return_400() {
+        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForNonPuiManager(), "Pending");
+    }
+
+    @Test
+    public void ac2_3_find_suspended_users_without_roles_for_an_organisation_with_non_pui_user_manager_role_should_return_400() {
+        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForNonPuiManager(), "Suspended");
+    }
+
+    @Test
     public void ac3_find_all_status_users_for_an_organisation_with_pui_user_manager_should_return_200() {
         Map<String, Object> response = professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.OK, generateBearerTokenForPuiManager(), "");
-        validateRetrievedUsers(response, true);
+        validateRetrievedUsers(response);
     }
 
     @Test
     public void ac4_find_all_active_users_for_an_organisation_with_pui_user_manager_should_return_200() {
         Map<String, Object> response = professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.OK, generateBearerTokenForPuiManager(), "Active");
-        validateRetrievedUsers(response, true);
+        validateRetrievedUsers(response);
     }
 
     @Test
@@ -178,7 +193,7 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
         professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForNonPuiManager(), "");
     }
 
-    void validateRetrievedUsers(Map<String, Object> searchResponse, Boolean rolesRequired) {
+    void validateRetrievedUsers(Map<String, Object> searchResponse) {
         assertThat(searchResponse.get("users")).asList().isNotEmpty();
 
         List<HashMap> professionalUsersResponses = (List<HashMap>) searchResponse.get("users");
@@ -190,7 +205,7 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
             assertThat(professionalUsersResponse.get("firstName")).isNotNull();
             assertThat(professionalUsersResponse.get("lastName")).isNotNull();
             assertThat(professionalUsersResponse.get("email")).isNotNull();
-            if (rolesRequired && professionalUsersResponse.get("idamStatus").equals(IdamStatus.ACTIVE.toString())) {
+            if (professionalUsersResponse.get("idamStatus").equals(IdamStatus.ACTIVE.toString())) {
                 assertThat(professionalUsersResponse.get("roles")).isNotNull();
             } else {
                 assertThat(professionalUsersResponse.get("roles")).isNull();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationTest.java
@@ -141,12 +141,7 @@ public class FindUsersByOrganisationTest extends AuthorizationFunctionalTest {
     public void ac5_find_all_suspended_users_for_an_organisation_with_pui_user_manager_when_no_suspended_user_exists_should_return_404() {
         professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.NOT_FOUND, generateBearerTokenForPuiManager(), "Suspended");
     }
-
-    @Test
-    public void ac5_1_find_all_deleted_users_for_an_organisation_with_pui_user_manager_when_no_deleted_user_exists_should_return_40() {
-        professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.NOT_FOUND, generateBearerTokenForPuiManager(), "Deleted");
-    }
-
+    
     @Test
     public void ac6_find_all_status_users_for_an_organisation_with_pui_user_manager_with_invalid_status_provided_should_return_400() {
         professionalApiClient.searchAllActiveUsersByOrganisationExternal(HttpStatus.BAD_REQUEST, generateBearerTokenForPuiManager(), "INVALID");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationIntegrationTest.java
@@ -122,7 +122,7 @@ public class FindUsersByOrganisationIntegrationTest extends AuthorizationEnabled
     public void retrieve_active_users_for_an_organisation_with_non_pui_user_manager_role_should_return_200() {
         UUID id = settingUpOrganisation("pui-case-manager");
         Map<String, Object> response = professionalReferenceDataClient.findAllUsersForOrganisationByStatus("false","Active", puiCaseManager, id);
-        validateUsers(response, 2, IdamStatus.ACTIVE.toString(), false);
+        validateUsers(response, 2, IdamStatus.ACTIVE.toString(), true);
     }
 
     @Test
@@ -154,12 +154,9 @@ public class FindUsersByOrganisationIntegrationTest extends AuthorizationEnabled
             assertThat(professionalUsersResponse.get("email")).isNotNull();
             if (expectedUserStatus.equalsIgnoreCase(IdamStatus.ACTIVE.toString())) {
                 assertThat(professionalUsersResponse.get("idamStatus")).isEqualTo(expectedUserStatus);
-            } else {
-                assertThat(professionalUsersResponse.get("idamStatus")).isNotNull();
-            }
-            if (isRolesRequired) {
                 assertThat(((List) professionalUsersResponse.get("roles")).size()).isEqualTo(1);
             } else {
+                assertThat(professionalUsersResponse.get("idamStatus")).isNotNull();
                 assertThat(((List) professionalUsersResponse.get("roles"))).isEmpty();
             }
         });

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersByOrganisationIntegrationTest.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
@@ -20,7 +19,7 @@ import uk.gov.hmcts.reform.professionalapi.utils.OrganisationFixtures;
 
 public class FindUsersByOrganisationIntegrationTest extends AuthorizationEnabledIntegrationTest {
 
-    private UUID settingUpOrganisation(String role) {
+    private String settingUpOrganisation(String role) {
         userProfileCreateUserWireMock(HttpStatus.CREATED);
         String organisationIdentifier = createOrganisationRequest();
         updateOrganisation(organisationIdentifier, hmctsAdmin, "ACTIVE");
@@ -39,7 +38,7 @@ public class FindUsersByOrganisationIntegrationTest extends AuthorizationEnabled
         Map<String, Object> newUserResponse =
                 professionalReferenceDataClient.addUserToOrganisation(organisationIdentifier, userCreationRequest, hmctsAdmin);
 
-        return UUID.fromString((String) newUserResponse.get("userIdentifier"));
+        return (String) newUserResponse.get("userIdentifier");
     }
 
 
@@ -48,7 +47,7 @@ public class FindUsersByOrganisationIntegrationTest extends AuthorizationEnabled
         String organisationIdentifier = createOrganisationRequest();
         updateOrganisation(organisationIdentifier, hmctsAdmin, "ACTIVE");
         Map<String, Object> response = professionalReferenceDataClient.findUsersByOrganisation(organisationIdentifier,"True", hmctsAdmin);
-        validateUsers(response, 3, "any", true);
+        validateUsers(response, 3);
     }
 
     @Test
@@ -56,7 +55,7 @@ public class FindUsersByOrganisationIntegrationTest extends AuthorizationEnabled
         String organisationIdentifier = createOrganisationRequest();
         updateOrganisation(organisationIdentifier, hmctsAdmin, "ACTIVE");
         Map<String, Object> response = professionalReferenceDataClient.findUsersByOrganisation(organisationIdentifier,"False", hmctsAdmin);
-        validateUsers(response, 3, "any", true);
+        validateUsers(response, 3);
     }
 
     @Test
@@ -64,7 +63,7 @@ public class FindUsersByOrganisationIntegrationTest extends AuthorizationEnabled
         String organisationIdentifier = createOrganisationRequest();
         updateOrganisation(organisationIdentifier, hmctsAdmin, "ACTIVE");
         Map<String, Object> response = professionalReferenceDataClient.findUsersByOrganisation(organisationIdentifier,null, hmctsAdmin);
-        validateUsers(response, 3, "any", true);
+        validateUsers(response, 3);
 
     }
 
@@ -120,44 +119,48 @@ public class FindUsersByOrganisationIntegrationTest extends AuthorizationEnabled
 
     @Test
     public void retrieve_active_users_for_an_organisation_with_non_pui_user_manager_role_should_return_200() {
-        UUID id = settingUpOrganisation("pui-case-manager");
+        String id = settingUpOrganisation("pui-case-manager");
         Map<String, Object> response = professionalReferenceDataClient.findAllUsersForOrganisationByStatus("false","Active", puiCaseManager, id);
-        validateUsers(response, 2, IdamStatus.ACTIVE.toString(), true);
+        validateUsers(response, 2);
     }
 
     @Test
     public void retrieve_active_users_for_an_organisation_with_pui_user_manager_role_should_return_200() {
-        UUID id = settingUpOrganisation("pui-user-manager");
+        String id = settingUpOrganisation("pui-user-manager");
         Map<String, Object> response = professionalReferenceDataClient.findAllUsersForOrganisationByStatus("false","Active", puiUserManager, id);
-        validateUsers(response, 2, IdamStatus.ACTIVE.toString(), true);
+        validateUsers(response, 2);
+    }
+
+    @Test
+    public void retrieve_deleted_users_for_an_organisation_with_pui_user_manager_role_should_return_400() {
+        String id = settingUpOrganisation("pui-user-manager");
+        Map<String, Object> response = professionalReferenceDataClient.findAllUsersForOrganisationByStatus("false","Deleted", puiUserManager, id);
+
     }
 
     @Test
     public void retrieve_all_users_for_an_organisation_with_pui_user_manager_role_should_return_200() {
-        UUID id = settingUpOrganisation("pui-user-manager");
+        String id = settingUpOrganisation("pui-user-manager");
         Map<String, Object> response = professionalReferenceDataClient.findAllUsersForOrganisationByStatus("false","", puiUserManager, id);
-        validateUsers(response, 3, "any", true);
+        validateUsers(response, 3);
     }
 
-    private void validateUsers(Map<String, Object> response, int expectedUserCount, String expectedUserStatus, boolean isRolesRequired) {
+    private void validateUsers(Map<String, Object> response, int expectedUserCount) {
 
         assertThat(response.get("http_status")).isEqualTo("200 OK");
         assertThat(((List<ProfessionalUsersResponse>) response.get("users")).size()).isEqualTo(expectedUserCount);
-
         List<HashMap> professionalUsersResponses = (List<HashMap>) response.get("users");
-        HashMap professionalUsersResponse = professionalUsersResponses.get(0);
 
         professionalUsersResponses.stream().forEach(user -> {
-            assertThat(professionalUsersResponse.get("userIdentifier")).isNotNull();
-            assertThat(professionalUsersResponse.get("firstName")).isNotNull();
-            assertThat(professionalUsersResponse.get("lastName")).isNotNull();
-            assertThat(professionalUsersResponse.get("email")).isNotNull();
-            if (expectedUserStatus.equalsIgnoreCase(IdamStatus.ACTIVE.toString())) {
-                assertThat(professionalUsersResponse.get("idamStatus")).isEqualTo(expectedUserStatus);
-                assertThat(((List) professionalUsersResponse.get("roles")).size()).isEqualTo(1);
+            assertThat(user.get("userIdentifier")).isNotNull();
+            assertThat(user.get("firstName")).isNotNull();
+            assertThat(user.get("lastName")).isNotNull();
+            assertThat(user.get("email")).isNotNull();
+            if (user.get("idamStatus").equals(IdamStatus.ACTIVE.toString())) {
+                assertThat(((List) user.get("roles")).size()).isEqualTo(1);
             } else {
-                assertThat(professionalUsersResponse.get("idamStatus")).isNotNull();
-                assertThat(((List) professionalUsersResponse.get("roles"))).isEmpty();
+                assertThat(user.get("idamStatus")).isNotNull();
+                assertThat(((List) user.get("roles"))).isEmpty();
             }
         });
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/util/AuthorizationEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/util/AuthorizationEnabledIntegrationTest.java
@@ -298,7 +298,7 @@ public abstract class AuthorizationEnabledIntegrationTest extends SpringBootInte
                 + "  \"firstName\": \"adil\","
                 + "  \"lastName\": \"oozeerally\","
                 + "  \"email\": \"adil.ooze@hmcts.net\","
-                + "  \"idamStatus\": \"" + IdamStatus.DELETED + "\","
+                + "  \"idamStatus\": \"DELETED\","
                 + "  \"roles\": [],"
                 + "  \"idamStatusCode\": \"404\","
                 + "  \"idamMessage\": \"16 Resource not found\""

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/util/ProfessionalReferenceDataClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/util/ProfessionalReferenceDataClient.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -93,7 +92,7 @@ public class ProfessionalReferenceDataClient {
         return getRequest(APP_INT_BASE_PATH + "/" + organisationIdentifier + "/users?showDeleted={showDeleted}", role, showDeleted);
     }
 
-    public Map<String, Object> findAllUsersForOrganisationByStatus(String showDeleted, String status, String role, UUID id) {
+    public Map<String, Object> findAllUsersForOrganisationByStatus(String showDeleted, String status, String role, String id) {
         return getRequestForExternal(APP_EXT_BASE_PATH + "/users?showDeleted={showDeleted}&status={status}",role, id, showDeleted, status);
     }
 
@@ -152,7 +151,7 @@ public class ProfessionalReferenceDataClient {
         return getResponse(responseEntity);
     }
 
-    private Map<String, Object> getRequestForExternal(String uriPath,String role, UUID userId, Object... params) {
+    private Map<String, Object> getRequestForExternal(String uriPath,String role, String userId, Object... params) {
 
         ResponseEntity<Map> responseEntity;
 
@@ -194,7 +193,7 @@ public class ProfessionalReferenceDataClient {
         return organisationResponse;
     }
 
-    private HttpHeaders getMultipleAuthHeaders(String role, UUID userId) {
+    private HttpHeaders getMultipleAuthHeaders(String role, String userId) {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON_UTF8);

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
@@ -88,15 +88,14 @@ public class ProfessionalExternalUserController extends SuperController {
             }
         } else {
 
-            if (isRolePuiUserManager) {
-                log.info("Searching for users with Pui User Manager role");
-                profUsersEntityResponse = searchUsersByOrganisation(organisationIdentifier, showDeleted, true, status);
-
-            } else {
+            if (!isRolePuiUserManager) {
+                if (StringUtils.isEmpty(status)) {
+                    status = "Active";
+                }
                 profExtUsrReqValidator.validateStatusIsActive(status);
-                log.info("Searching for users with NON Pui User Manager role");
-                profUsersEntityResponse = searchUsersByOrganisation(organisationIdentifier, showDeleted, false, status);
             }
+
+            profUsersEntityResponse = searchUsersByOrganisation(organisationIdentifier, showDeleted, true, status);
         }
 
         return profUsersEntityResponse;

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/response/IdamStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/response/IdamStatus.java
@@ -1,5 +1,5 @@
 package uk.gov.hmcts.reform.professionalapi.controller.response;
 
 public enum IdamStatus {
-    ACTIVE,PENDING,SUSPENDED,DELETED
+    ACTIVE,PENDING,SUSPENDED
 }

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/response/ProfessionalUsersResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/response/ProfessionalUsersResponse.java
@@ -26,7 +26,7 @@ public class ProfessionalUsersResponse {
     @JsonProperty
     private List<String> roles;
     @JsonProperty
-    private IdamStatus idamStatus;
+    private String idamStatus;
     @JsonProperty
     private String idamStatusCode;
     @JsonProperty
@@ -38,7 +38,7 @@ public class ProfessionalUsersResponse {
         this.lastName = user.getLastName();
         this.email = user.getEmailAddress();
         this.roles = user.getRoles();
-        this.idamStatus = user.getIdamStatus();
+        this.idamStatus = user.getIdamStatus() ==  null ? "" :  user.getIdamStatus().toString();
         this.idamStatusCode = StringUtils.isBlank(user.getIdamStatusCode()) ? "" : user.getIdamStatusCode();
         this.idamMessage = StringUtils.isBlank(user.getIdamMessage()) ? "" : user.getIdamMessage();
     }

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/service/ProfessionalUserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/service/ProfessionalUserServiceTest.java
@@ -197,9 +197,9 @@ public class ProfessionalUserServiceTest {
         ProfessionalUsersResponse professionalUsersResponse = new ProfessionalUsersResponse(new ProfessionalUser("fName","lName", "some@email.com", organisationMock));
         ProfessionalUsersResponse professionalUsersResponse1 = new ProfessionalUsersResponse(new ProfessionalUser("fName1","lName1", "some1@email.com", organisationMock));
         ProfessionalUsersResponse professionalUsersResponse2 = new ProfessionalUsersResponse(new ProfessionalUser("fName2","lName2", "some2@email.com", organisationMock));
-        professionalUsersResponse.setIdamStatus(IdamStatus.ACTIVE);
-        professionalUsersResponse1.setIdamStatus(IdamStatus.ACTIVE);
-        professionalUsersResponse2.setIdamStatus(IdamStatus.PENDING);
+        professionalUsersResponse.setIdamStatus(IdamStatus.ACTIVE.toString());
+        professionalUsersResponse1.setIdamStatus(IdamStatus.ACTIVE.toString());
+        professionalUsersResponse2.setIdamStatus(IdamStatus.PENDING.toString());
         List<ProfessionalUsersResponse> userProfiles = new ArrayList<>();
         userProfiles.add(professionalUsersResponse);
         userProfiles.add(professionalUsersResponse1);

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/utils/RefDataUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/utils/RefDataUtilTest.java
@@ -174,9 +174,9 @@ public class RefDataUtilTest {
         ProfessionalUsersResponse professionalUsersResponse = new ProfessionalUsersResponse(new ProfessionalUser("fName","lName", "some@email.com", organisationMock));
         ProfessionalUsersResponse professionalUsersResponse1 = new ProfessionalUsersResponse(new ProfessionalUser("fName1","lName1", "some1@email.com", organisationMock));
         ProfessionalUsersResponse professionalUsersResponse2 = new ProfessionalUsersResponse(new ProfessionalUser("fName2","lName2", "some2@email.com", organisationMock));
-        professionalUsersResponse.setIdamStatus(IdamStatus.ACTIVE);
-        professionalUsersResponse1.setIdamStatus(IdamStatus.ACTIVE);
-        professionalUsersResponse2.setIdamStatus(IdamStatus.PENDING);
+        professionalUsersResponse.setIdamStatus(IdamStatus.ACTIVE.toString());
+        professionalUsersResponse1.setIdamStatus(IdamStatus.ACTIVE.toString());
+        professionalUsersResponse2.setIdamStatus(IdamStatus.PENDING.toString());
         List<ProfessionalUsersResponse> userProfiles = new ArrayList<>();
         userProfiles.add(professionalUsersResponse);
         userProfiles.add(professionalUsersResponse1);
@@ -209,9 +209,9 @@ public class RefDataUtilTest {
         ProfessionalUsersResponse professionalUsersResponse1 = new ProfessionalUsersResponse(new ProfessionalUser("fName1","lName1", "some1@email.com", organisationMock));
         ProfessionalUsersResponse professionalUsersResponse2 = new ProfessionalUsersResponse(new ProfessionalUser("fName2","lName2", "some2@email.com", organisationMock));
 
-        professionalUsersResponse.setIdamStatus(IdamStatus.ACTIVE);
-        professionalUsersResponse1.setIdamStatus(IdamStatus.ACTIVE);
-        professionalUsersResponse2.setIdamStatus(IdamStatus.PENDING);
+        professionalUsersResponse.setIdamStatus(IdamStatus.ACTIVE.toString());
+        professionalUsersResponse1.setIdamStatus(IdamStatus.ACTIVE.toString());
+        professionalUsersResponse2.setIdamStatus(IdamStatus.PENDING.toString());
 
         List<ProfessionalUsersResponse> userProfiles = new ArrayList<>();
         userProfiles.add(professionalUsersResponse);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-496

### Change description ###

If the role of the user who is calling the Endpoint to Retrieve the list of users is NOT pui-user-manager, then Retrieve/Get users with roles and

'Active' users only when no parameter is passed for the 'user status' in the request 
'Active' users only when 'status' field parameter is passed as 'Active'
Error message when request parameter is anything other than the 'Active' status for e.g.: Pending/Suspended, etc.

All requests will now come with roles

**Does this PR introduce a breaking change?** (check one with "✓")

```
[ ] Yes
[✓] No
```
