### PR TITLE
RDCC-531 splitting search user by email and search users by organisat…

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/client/ProfessionalApiClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/client/ProfessionalApiClient.java
@@ -213,7 +213,7 @@ public class ProfessionalApiClient {
     public Map<String, Object> searchForUserByEmailAddress(String email, String role) {
         Response response = getMultipleAuthHeadersInternal()
                 .param("email", email)
-                .get("/refdata/internal/v1/organisations/users")
+                .get("/refdata/internal/v1/organisations/user")
                 .andReturn();
         log.info("Search For User By Email Response: " + response.asString());
         response.then()

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/CreateMinimalOrganisationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/CreateMinimalOrganisationTest.java
@@ -5,8 +5,8 @@ import static uk.gov.hmcts.reform.professionalapi.controller.request.ContactInfo
 import static uk.gov.hmcts.reform.professionalapi.controller.request.DxAddressCreationRequest.dxAddressCreationRequest;
 import static uk.gov.hmcts.reform.professionalapi.controller.request.OrganisationCreationRequest.anOrganisationCreationRequest;
 import static uk.gov.hmcts.reform.professionalapi.controller.request.UserCreationRequest.aUserCreationRequest;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_ORGANISATION_IDENTIFIER;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.ORGANISATION_IDENTIFIER_FORMAT_REGEX;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_ORGANISATION_IDENTIFIER;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.ORGANISATION_IDENTIFIER_FORMAT_REGEX;
 import static uk.gov.hmcts.reform.professionalapi.utils.OrganisationFixtures.someMinimalOrganisationRequest;
 import static uk.gov.hmcts.reform.professionalapi.utils.OrganisationFixtures.whiteSpaceTrimOrganisationRequest;
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/util/ProfessionalReferenceDataClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/util/ProfessionalReferenceDataClient.java
@@ -53,7 +53,7 @@ public class ProfessionalReferenceDataClient {
     }
 
     public Map<String, Object> findUserByEmail(String email, String role) {
-        return getRequest(APP_INT_BASE_PATH + "/users?email={email}", role,email);
+        return getRequest(APP_INT_BASE_PATH + "/user?email={email}", role,email);
     }
 
     public Map<String, Object> findPaymentAccountsByEmail(String email, String role) {

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.professionalapi.controller;
 
+import static uk.gov.hmcts.reform.professionalapi.controller.request.OrganisationCreationRequestValidator.validateEmail;
+
 import feign.FeignException;
 import feign.Response;
 import java.util.List;
@@ -47,6 +49,7 @@ import uk.gov.hmcts.reform.professionalapi.service.ProfessionalUserService;
 import uk.gov.hmcts.reform.professionalapi.service.impl.JurisdictionServiceImpl;
 import uk.gov.hmcts.reform.professionalapi.util.JsonFeignResponseHelper;
 import uk.gov.hmcts.reform.professionalapi.util.RefDataUtil;
+
 
 @RestController
 @Slf4j
@@ -106,7 +109,7 @@ public abstract class SuperController {
         }
 
         if (organisationCreationRequest.getSuperUser() != null) {
-            organisationCreationRequestValidator.validateEmail(organisationCreationRequest.getSuperUser().getEmail());
+            validateEmail(organisationCreationRequest.getSuperUser().getEmail());
         }
 
         organisationCreationRequestValidator.validateJurisdictions(organisationCreationRequest.getSuperUser().getJurisdictions(), prdEnumService.getPrdEnumByEnumType(jurisdictionIds));
@@ -267,7 +270,7 @@ public abstract class SuperController {
 
         Object responseBody = null;
         OrganisationCreationRequestValidator.validateNewUserCreationRequestForMandatoryFields(newUserCreationRequest);
-        OrganisationCreationRequestValidator.validateEmail(newUserCreationRequest.getEmail());
+        validateEmail(newUserCreationRequest.getEmail());
         organisationCreationRequestValidator.validateOrganisationIdentifier(orgId);
         Organisation existingOrganisation = organisationService.getOrganisationByOrgIdentifier(orgId);
         organisationCreationRequestValidator.isOrganisationActive(existingOrganisation);

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
@@ -163,7 +163,7 @@ public abstract class SuperController {
                 .body(organisationResponse);
     }
 
-    protected ResponseEntity<?> retrieveUserByEmail(String email) {
+    protected ResponseEntity<ProfessionalUsersResponse> retrieveUserByEmail(String email) {
 
         ProfessionalUser user = professionalUserService.findProfessionalUserProfileByEmailAddress(RefDataUtil.removeEmptySpaces(email));
 

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
@@ -108,7 +108,7 @@ public abstract class SuperController {
             organisationCreationRequest.setSraRegulated(SRA_REGULATED_FALSE);
         }
 
-        if (organisationCreationRequest.getSuperUser() != null) {
+        if (null != organisationCreationRequest.getSuperUser()) {
             validateEmail(organisationCreationRequest.getSuperUser().getEmail());
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
@@ -97,7 +97,7 @@ public abstract class SuperController {
     @Value("${jurisdictionIdType}")
     private String jurisdictionIds;
 
-    private final String sraRegulatedFalse = "false";
+    static final String sraRegulatedFalse = "false";
 
     protected ResponseEntity<OrganisationResponse>  createOrganisationFrom(OrganisationCreationRequest organisationCreationRequest) {
 

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
@@ -97,7 +97,7 @@ public abstract class SuperController {
     @Value("${jurisdictionIdType}")
     private String jurisdictionIds;
 
-    static final String sraRegulatedFalse = "false";
+    static final String SRA_REGULATED_FALSE = "false";
 
     protected ResponseEntity<OrganisationResponse>  createOrganisationFrom(OrganisationCreationRequest organisationCreationRequest) {
 
@@ -105,7 +105,7 @@ public abstract class SuperController {
         organisationCreationRequestValidator.validateJurisdictions(organisationCreationRequest.getSuperUser().getJurisdictions(), prdEnumService.getPrdEnumByEnumType(jurisdictionIds));
 
         if (StringUtils.isBlank(organisationCreationRequest.getSraRegulated())) {
-            organisationCreationRequest.setSraRegulated(sraRegulatedFalse);
+            organisationCreationRequest.setSraRegulated(SRA_REGULATED_FALSE);
         }
 
         if (organisationCreationRequest.getSuperUser() != null) {
@@ -119,7 +119,7 @@ public abstract class SuperController {
         }
 
         if (StringUtils.isBlank(organisationCreationRequest.getSraRegulated())) {
-            organisationCreationRequest.setSraRegulated(sraRegulatedFalse);
+            organisationCreationRequest.setSraRegulated(SRA_REGULATED_FALSE);
         }
 
         OrganisationResponse organisationResponse =
@@ -196,7 +196,7 @@ public abstract class SuperController {
         String orgId = RefDataUtil.removeEmptySpaces(organisationIdentifier);
 
         if (StringUtils.isBlank(organisationCreationRequest.getSraRegulated())) {
-            organisationCreationRequest.setSraRegulated(sraRegulatedFalse);
+            organisationCreationRequest.setSraRegulated(SRA_REGULATED_FALSE);
         }
 
         organisationCreationRequestValidator.validate(organisationCreationRequest);

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
@@ -73,7 +73,6 @@ public abstract class SuperController {
     @Autowired
     private JurisdictionServiceImpl jurisdictionService;
 
-
     @Value("${exui.role.hmcts-admin:}")
     protected String prdAdmin;
 
@@ -95,13 +94,15 @@ public abstract class SuperController {
     @Value("${jurisdictionIdType}")
     private String jurisdictionIds;
 
+    private final String sraRegulatedFalse = "false";
+
     protected ResponseEntity<OrganisationResponse>  createOrganisationFrom(OrganisationCreationRequest organisationCreationRequest) {
 
         organisationCreationRequestValidator.validate(organisationCreationRequest);
         organisationCreationRequestValidator.validateJurisdictions(organisationCreationRequest.getSuperUser().getJurisdictions(), prdEnumService.getPrdEnumByEnumType(jurisdictionIds));
 
         if (StringUtils.isBlank(organisationCreationRequest.getSraRegulated())) {
-            organisationCreationRequest.setSraRegulated("false");
+            organisationCreationRequest.setSraRegulated(sraRegulatedFalse);
         }
 
         if (organisationCreationRequest.getSuperUser() != null) {
@@ -115,7 +116,7 @@ public abstract class SuperController {
         }
 
         if (StringUtils.isBlank(organisationCreationRequest.getSraRegulated())) {
-            organisationCreationRequest.setSraRegulated("false");
+            organisationCreationRequest.setSraRegulated(sraRegulatedFalse);
         }
 
         OrganisationResponse organisationResponse =
@@ -127,7 +128,7 @@ public abstract class SuperController {
                 .body(organisationResponse);
     }
 
-    protected ResponseEntity<?> retrieveAllOrganisationOrById(String organisationIdentifier, String status) {
+    protected ResponseEntity retrieveAllOrganisationOrById(String organisationIdentifier, String status) {
         String orgId = RefDataUtil.removeEmptySpaces(organisationIdentifier);
         String orgStatus = RefDataUtil.removeEmptySpaces(status);
 
@@ -163,7 +164,7 @@ public abstract class SuperController {
                 .body(organisationResponse);
     }
 
-    protected ResponseEntity<ProfessionalUsersResponse> retrieveUserByEmail(String email) {
+    protected ResponseEntity retrieveUserByEmail(String email) {
 
         ProfessionalUser user = professionalUserService.findProfessionalUserProfileByEmailAddress(RefDataUtil.removeEmptySpaces(email));
 
@@ -173,7 +174,7 @@ public abstract class SuperController {
                 .body(professionalUsersResponse);
     }
 
-    protected ResponseEntity<?> retrievePaymentAccountByUserEmail(String email) {
+    protected ResponseEntity retrievePaymentAccountByUserEmail(String email) {
 
         Organisation organisation = paymentAccountService.findPaymentAccountsByEmail(RefDataUtil.removeEmptySpaces(email));
         if (null == organisation || organisation.getPaymentAccounts().isEmpty()) {
@@ -186,13 +187,13 @@ public abstract class SuperController {
                 .body(new OrganisationPbaResponse(organisation, false));
     }
 
-    protected ResponseEntity<?> updateOrganisationById(OrganisationCreationRequest organisationCreationRequest, String organisationIdentifier, String userId) {
+    protected ResponseEntity updateOrganisationById(OrganisationCreationRequest organisationCreationRequest, String organisationIdentifier, String userId) {
         organisationCreationRequest.setStatus(organisationCreationRequest.getStatus().toUpperCase());
 
         String orgId = RefDataUtil.removeEmptySpaces(organisationIdentifier);
 
         if (StringUtils.isBlank(organisationCreationRequest.getSraRegulated())) {
-            organisationCreationRequest.setSraRegulated("false");
+            organisationCreationRequest.setSraRegulated(sraRegulatedFalse);
         }
 
         organisationCreationRequestValidator.validate(organisationCreationRequest);
@@ -245,7 +246,7 @@ public abstract class SuperController {
         }
     }
 
-    protected ResponseEntity<?> retrieveAllOrganisationsByStatus(String status) {
+    protected ResponseEntity retrieveAllOrganisationsByStatus(String status) {
         String orgStatus = RefDataUtil.removeEmptySpaces(status);
 
         OrganisationsDetailResponse organisationsDetailResponse;
@@ -261,7 +262,7 @@ public abstract class SuperController {
         return ResponseEntity.status(200).body(organisationsDetailResponse);
     }
 
-    protected ResponseEntity<?> inviteUserToOrganisation(NewUserCreationRequest newUserCreationRequest, String organisationIdentifier, String userId) {
+    protected ResponseEntity inviteUserToOrganisation(NewUserCreationRequest newUserCreationRequest, String organisationIdentifier, String userId) {
         String orgId = RefDataUtil.removeEmptySpaces(organisationIdentifier);
 
         Object responseBody = null;
@@ -301,7 +302,7 @@ public abstract class SuperController {
                 .body(responseBody);
     }
 
-    protected ResponseEntity<?> searchUsersByOrganisation(String organisationIdentifier, String showDeleted, boolean rolesRequired, String status, Integer page, Integer size) {
+    protected ResponseEntity searchUsersByOrganisation(String organisationIdentifier, String showDeleted, boolean rolesRequired, String status, Integer page, Integer size) {
 
         organisationCreationRequestValidator.validateOrganisationIdentifier(organisationIdentifier);
         Organisation existingOrganisation = organisationService.getOrganisationByOrgIdentifier(organisationIdentifier);

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/OrganisationExternalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/OrganisationExternalController.java
@@ -159,7 +159,7 @@ public class OrganisationExternalController extends SuperController {
     )
     @ResponseBody
     @Secured("pui-user-manager")
-    public ResponseEntity<?> addUserToOrganisationUsingExternalController(
+    public ResponseEntity addUserToOrganisationUsingExternalController(
             @Valid @NotNull @RequestBody NewUserCreationRequest newUserCreationRequest,
             @ApiParam(hidden = true)@OrgId String organisationIdentifier,
             @ApiParam(hidden = true) @UserId String userId) {

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.professionalapi.controller.external;
 
+import static uk.gov.hmcts.reform.professionalapi.controller.request.ProfessionalUserReqValidator.isValidEmail;
+
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
@@ -32,7 +34,6 @@ import uk.gov.hmcts.reform.professionalapi.controller.response.ProfessionalUsers
 import uk.gov.hmcts.reform.professionalapi.domain.ModifyUserProfileData;
 import uk.gov.hmcts.reform.professionalapi.domain.ModifyUserRolesResponse;
 
-import static uk.gov.hmcts.reform.professionalapi.controller.request.ProfessionalUserReqValidator.isValidEmail;
 
 @RequestMapping(
         path = "refdata/external/v1/organisations",

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
@@ -152,7 +152,7 @@ public class ProfessionalExternalUserController extends SuperController {
             log.info("email is valid");
             optionalResponseEntity = Optional.ofNullable(retrieveUserByEmail(email));
         } else {
-            throw new InvalidRequest("The email provided is invalid");
+            throw new InvalidRequest("The email provided '" + email + "' is invalid");
         }
 
         if (optionalResponseEntity.isPresent()) {

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
@@ -32,6 +32,8 @@ import uk.gov.hmcts.reform.professionalapi.controller.response.ProfessionalUsers
 import uk.gov.hmcts.reform.professionalapi.domain.ModifyUserProfileData;
 import uk.gov.hmcts.reform.professionalapi.domain.ModifyUserRolesResponse;
 
+import static uk.gov.hmcts.reform.professionalapi.controller.request.ProfessionalUserReqValidator.isValidEmail;
+
 @RequestMapping(
         path = "refdata/external/v1/organisations",
         produces = MediaType.APPLICATION_JSON_UTF8_VALUE
@@ -143,7 +145,7 @@ public class ProfessionalExternalUserController extends SuperController {
 
         ResponseEntity<ProfessionalUsersResponse> profUsersEntityResponse = null;
         log.info("ProfessionalExternalUserController::findUserByEmail:" + email);
-        profExtUsrReqValidator.isValidEmail(email);
+        isValidEmail(email);
         ServiceAndUserDetails serviceAndUserDetails = (ServiceAndUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         boolean isRolePuiUserManager = organisationIdentifierValidatorImpl.ifUserRoleExists(serviceAndUserDetails.getAuthorities(), "pui-user-manager");
 

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/internal/OrganisationInternalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/internal/OrganisationInternalController.java
@@ -86,7 +86,7 @@ public class OrganisationInternalController extends SuperController {
 
     @Secured("prd-admin")
     @GetMapping(produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public ResponseEntity<?> retrieveOrganisations(
+    public ResponseEntity retrieveOrganisations(
             @ApiParam(name = "id", required = false)@RequestParam(value = "id", required = false) String id,
             @ApiParam(name = "status", required = false)@RequestParam(value = "status", required = false) String status) {
 
@@ -122,7 +122,7 @@ public class OrganisationInternalController extends SuperController {
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     @Secured("prd-admin")
-    public ResponseEntity<?> retrievePaymentAccountBySuperUserEmail(@NotNull @RequestParam("email") String email) {
+    public ResponseEntity retrievePaymentAccountBySuperUserEmail(@NotNull @RequestParam("email") String email) {
         log.info("Received request to retrieve an organisations payment accounts by email for internal...");
         return retrievePaymentAccountByUserEmail(email);
     }
@@ -145,7 +145,7 @@ public class OrganisationInternalController extends SuperController {
     )
     @ResponseBody
     @Secured("prd-admin")
-    public ResponseEntity<?> updatesOrganisation(
+    public ResponseEntity updatesOrganisation(
             @Valid @NotNull @RequestBody OrganisationCreationRequest organisationCreationRequest,
             @PathVariable("orgId") @NotBlank String organisationIdentifier,
             @ApiParam(hidden = true) @UserId String userId) {
@@ -182,7 +182,7 @@ public class OrganisationInternalController extends SuperController {
     )
     @ResponseBody
     @Secured("prd-admin")
-    public ResponseEntity<?> addUserToOrganisation(
+    public ResponseEntity addUserToOrganisation(
             @Valid @NotNull @RequestBody NewUserCreationRequest newUserCreationRequest,
             @PathVariable("orgId") @NotBlank String organisationIdentifier,
             @ApiParam(hidden = true) @UserId String userId) {

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/internal/ProfessionalUserInternalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/internal/ProfessionalUserInternalController.java
@@ -68,7 +68,7 @@ public class ProfessionalUserInternalController extends SuperController {
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     @Secured("prd-admin")
-    public ResponseEntity  findUsersByOrganisation(@PathVariable("orgId") @NotBlank String organisationIdentifier,
+    public ResponseEntity findUsersByOrganisation(@PathVariable("orgId") @NotBlank String organisationIdentifier,
                                                       @RequestParam(value = "showDeleted", required = false) String showDeleted,
                                                       @RequestParam(value = "page", required = false) Integer page,
                                                       @RequestParam(value = "size", required = false) Integer size) {
@@ -107,7 +107,7 @@ public class ProfessionalUserInternalController extends SuperController {
             )
     })
     @GetMapping(
-            value = "/users",
+            value = "/user",
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     @Secured("prd-admin")

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/internal/ProfessionalUserInternalController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/internal/ProfessionalUserInternalController.java
@@ -68,7 +68,7 @@ public class ProfessionalUserInternalController extends SuperController {
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     @Secured("prd-admin")
-    public ResponseEntity<?>  findUsersByOrganisation(@PathVariable("orgId") @NotBlank String organisationIdentifier,
+    public ResponseEntity  findUsersByOrganisation(@PathVariable("orgId") @NotBlank String organisationIdentifier,
                                                       @RequestParam(value = "showDeleted", required = false) String showDeleted,
                                                       @RequestParam(value = "page", required = false) Integer page,
                                                       @RequestParam(value = "size", required = false) Integer size) {
@@ -111,7 +111,7 @@ public class ProfessionalUserInternalController extends SuperController {
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     @Secured("prd-admin")
-    public ResponseEntity<?> findUserByEmail(@RequestParam(value = "email") String email) {
+    public ResponseEntity findUserByEmail(@RequestParam(value = "email") String email) {
 
         return retrieveUserByEmail(email);
     }

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/request/OrganisationCreationRequestValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/request/OrganisationCreationRequestValidator.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.professionalapi.controller.request;
 
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_ORGANISATION_IDENTIFIER;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.ORGANISATION_IDENTIFIER_FORMAT_REGEX;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_ORGANISATION_IDENTIFIER;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.ORGANISATION_IDENTIFIER_FORMAT_REGEX;
 
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/request/ProfessionalUserReqValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/request/ProfessionalUserReqValidator.java
@@ -21,16 +21,17 @@ import uk.gov.hmcts.reform.professionalapi.domain.RoleName;
 public class ProfessionalUserReqValidator {
 
     public static boolean isValidEmail(String email) {
-        if (email != null) {
-            Pattern p = Pattern.compile("\\\\A(?=[a-zA-Z0-9@.!#$%&'*+/=?^_`{|}~-]{6,254}\\\\z)(?=[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]\" + \"{1,64}@)[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\\\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:(?=[a-zA-Z0-9-]{1,63}\" + \"\\\\.)[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\\\.)+(?=[a-zA-Z0-9-]{1,63}\\\\z)[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\\\\z\" + \"'?[- a-zA-Z]+$\";\n");
+        if (!StringUtils.isEmpty(email)) {
+            Pattern p = Pattern.compile("(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])");
             Matcher m = p.matcher(email);
             return m.find();
         }
+
         return false;
     }
 
     public void validateRequest(String orgId, String showDeleted, String status) {
-        if (null == orgId  && null == showDeleted) {
+        if (StringUtils.isEmpty(orgId) && StringUtils.isEmpty(showDeleted)) {
             throw new InvalidRequest("No input values given for the request");
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/request/ProfessionalUserReqValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/request/ProfessionalUserReqValidator.java
@@ -29,16 +29,14 @@ public class ProfessionalUserReqValidator {
         return false;
     }
 
-    public void validateRequest(String orgId, String showDeleted, String email, String status) {
-        if (null == orgId  && null == email && null == showDeleted) {
+    public void validateRequest(String orgId, String showDeleted, String status) {
+        if (null == orgId  && null == showDeleted) {
             throw new InvalidRequest("No input values given for the request");
         }
 
         if (!StringUtils.isEmpty(status)) {
             validateUserStatus(status);
         }
-
-        isValidEmail(email);
     }
 
     public static void validateUserStatus(String status) {

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/domain/Organisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/domain/Organisation.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.professionalapi.domain;
 
 import static javax.persistence.GenerationType.AUTO;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_ORGANISATION_IDENTIFIER;
 import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.generateUniqueAlphanumericId;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_ORGANISATION_IDENTIFIER;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/generator/ProfessionalApiGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/generator/ProfessionalApiGenerator.java
@@ -9,9 +9,6 @@ import org.apache.commons.lang3.RandomStringUtils;
  */
 
 public interface ProfessionalApiGenerator {
-    int LENGTH_OF_UUID = 36;
-    int LENGTH_OF_ORGANISATION_IDENTIFIER = 7;
-    String ORGANISATION_IDENTIFIER_FORMAT_REGEX = "^(?=.*[A-Z])(?=.*[0-9])[A-Z0-9]{7}$";
 
     /**
      * Generates UUID which is unique.
@@ -38,7 +35,7 @@ public interface ProfessionalApiGenerator {
         String generatedString = null;
         while (true) {
             generatedString = RandomStringUtils.randomAlphanumeric(lengthOfString);
-            if (generatedString.matches(ORGANISATION_IDENTIFIER_FORMAT_REGEX)) {
+            if (generatedString.matches(ProfessionalApiGeneratorConstants.ORGANISATION_IDENTIFIER_FORMAT_REGEX)) {
                 break;
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/generator/ProfessionalApiGeneratorConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/generator/ProfessionalApiGeneratorConstants.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.professionalapi.generator;
+
+public class ProfessionalApiGeneratorConstants {
+
+    private ProfessionalApiGeneratorConstants() {
+    }
+
+    public static final int LENGTH_OF_UUID = 36;
+    public static final int LENGTH_OF_ORGANISATION_IDENTIFIER = 7;
+    public static final String ORGANISATION_IDENTIFIER_FORMAT_REGEX = "^(?=.*[A-Z])(?=.*[0-9])[A-Z0-9]{7}$";
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/service/impl/OrganisationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/service/impl/OrganisationServiceImpl.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.professionalapi.service.impl;
 
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_ORGANISATION_IDENTIFIER;
 import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.generateUniqueAlphanumericId;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_ORGANISATION_IDENTIFIER;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/TestConstants.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/TestConstants.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.professionalapi;
+
+public class TestConstants {
+
+    private TestConstants() {
+
+    }
+
+    public static final String PUI_USER_MANAGER = "pui-user-manager";
+    public static final String PUI_CASE_MANAGER = "pui-case-manager";
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/ProfessionalExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/ProfessionalExternalUserControllerTest.java
@@ -6,10 +6,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -138,5 +135,42 @@ public class ProfessionalExternalUserControllerTest {
         ResponseEntity<?> actual = professionalExternalUserController.findUsersByOrganisation(organisation.getOrganisationIdentifier(), "true", "Pending", null, null);
         assertThat(actual).isNotNull();
         assertThat(actual.getStatusCode().value()).isEqualTo(expectedHttpStatus.value());
+    }
+
+    @Test
+    public void testFindUserByEmailWithPuiUserManager() {
+        final HttpStatus expectedHttpStatus = HttpStatus.OK;
+        ProfessionalUser professionalUser = new ProfessionalUser("fName", "lastName", "test@email.com", organisation);
+        List<SuperUser> users = new ArrayList<>();
+        users.add(professionalUser.toSuperUser());
+        organisation.setUsers(users);
+        organisation.setStatus(OrganisationStatus.ACTIVE);
+
+        Authentication authentication = mock(Authentication.class);
+        GrantedAuthority grantedAuthority = mock(GrantedAuthority.class);
+        Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+        when(grantedAuthority.getAuthority()).thenReturn("pui-user-manager");
+        authorities.add(grantedAuthority);
+        ServiceAndUserDetails serviceAndUserDetails = mock(ServiceAndUserDetails.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(securityContext.getAuthentication().getPrincipal()).thenReturn(serviceAndUserDetails);
+        when(serviceAndUserDetails.getAuthorities()).thenReturn(authorities);
+        SecurityContextHolder.setContext(securityContext);
+
+        when(organisation.getOrganisationIdentifier()).thenReturn(UUID.randomUUID().toString());
+        when(organisation.getStatus()).thenReturn(OrganisationStatus.ACTIVE);
+        when(organisationServiceMock.getOrganisationByOrgIdentifier(organisation.getOrganisationIdentifier())).thenReturn(organisation);
+        when(professionalUserServiceMock.findProfessionalUserProfileByEmailAddress("testing@email.com")).thenReturn(professionalUser);
+        when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, "pui-user-manager")).thenReturn(true);
+        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
+
+        doNothing().when(profExtUsrReqValidator).validateRequest(any(String.class), any(String.class), any(String.class));
+        doNothing().when(organisationIdentifierValidatorImpl).validate(any(Organisation.class), any(OrganisationStatus.class), any(String.class));
+        doNothing().when(organisationCreationRequestValidator).validateOrganisationIdentifier(any(String.class));
+
+        Optional<ResponseEntity> actual = professionalExternalUserController.findUserByEmail(organisation.getOrganisationIdentifier(), "testing@email.com");
+        assertThat(actual).isNotNull();
+        assertThat(actual.get().getStatusCode().value()).isEqualTo(expectedHttpStatus.value());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/ProfessionalExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/ProfessionalExternalUserControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.reform.auth.checker.spring.serviceanduser.ServiceAndUserDetails;
+import uk.gov.hmcts.reform.professionalapi.TestConstants;
 import uk.gov.hmcts.reform.professionalapi.controller.external.ProfessionalExternalUserController;
 import uk.gov.hmcts.reform.professionalapi.controller.request.OrganisationCreationRequestValidator;
 import uk.gov.hmcts.reform.professionalapi.controller.request.OrganisationIdentifierValidatorImpl;
@@ -70,7 +71,7 @@ public class ProfessionalExternalUserControllerTest {
         Authentication authentication = mock(Authentication.class);
         GrantedAuthority grantedAuthority = mock(GrantedAuthority.class);
         Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-        when(grantedAuthority.getAuthority()).thenReturn("pui-user-manager");
+        when(grantedAuthority.getAuthority()).thenReturn(TestConstants.PUI_USER_MANAGER);
         authorities.add(grantedAuthority);
 
         ServiceAndUserDetails serviceAndUserDetails = mock(ServiceAndUserDetails.class);
@@ -85,7 +86,7 @@ public class ProfessionalExternalUserControllerTest {
         when(organisationServiceMock.getOrganisationByOrgIdentifier(organisation.getOrganisationIdentifier())).thenReturn(organisation);
         when(professionalUserServiceMock.findProfessionalUserProfileByEmailAddress("emailAddress")).thenReturn(professionalUser);
         when(professionalUserServiceMock.findProfessionalUsersByOrganisation(any(Organisation.class), any(String.class), any(Boolean.class), any(String.class))).thenReturn(responseEntity);
-        when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, "pui-user-manager")).thenReturn(true);
+        when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, TestConstants.PUI_USER_MANAGER)).thenReturn(true);
         when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
 
         doNothing().when(profExtUsrReqValidator).validateRequest(any(String.class), any(String.class), any(String.class));
@@ -110,7 +111,7 @@ public class ProfessionalExternalUserControllerTest {
         Authentication authentication = mock(Authentication.class);
         GrantedAuthority grantedAuthority = mock(GrantedAuthority.class);
         Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-        when(grantedAuthority.getAuthority()).thenReturn("pui-user-manager");
+        when(grantedAuthority.getAuthority()).thenReturn(TestConstants.PUI_USER_MANAGER);
         authorities.add(grantedAuthority);
 
         ServiceAndUserDetails serviceAndUserDetails = mock(ServiceAndUserDetails.class);
@@ -125,7 +126,7 @@ public class ProfessionalExternalUserControllerTest {
         when(organisationServiceMock.getOrganisationByOrgIdentifier(organisation.getOrganisationIdentifier())).thenReturn(organisation);
         when(professionalUserServiceMock.findProfessionalUserProfileByEmailAddress("emailAddress")).thenReturn(professionalUser);
         when(professionalUserServiceMock.findProfessionalUsersByOrganisation(any(Organisation.class), any(String.class), any(Boolean.class), any(String.class))).thenReturn(responseEntity);
-        when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, "pui-case-manager")).thenReturn(true);
+        when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, TestConstants.PUI_CASE_MANAGER)).thenReturn(true);
         when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
 
         doNothing().when(profExtUsrReqValidator).validateRequest(any(String.class), any(String.class), any(String.class));
@@ -149,7 +150,7 @@ public class ProfessionalExternalUserControllerTest {
         Authentication authentication = mock(Authentication.class);
         GrantedAuthority grantedAuthority = mock(GrantedAuthority.class);
         Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-        when(grantedAuthority.getAuthority()).thenReturn("pui-user-manager");
+        when(grantedAuthority.getAuthority()).thenReturn(TestConstants.PUI_USER_MANAGER);
         authorities.add(grantedAuthority);
         ServiceAndUserDetails serviceAndUserDetails = mock(ServiceAndUserDetails.class);
         SecurityContext securityContext = mock(SecurityContext.class);
@@ -162,7 +163,7 @@ public class ProfessionalExternalUserControllerTest {
         when(organisation.getStatus()).thenReturn(OrganisationStatus.ACTIVE);
         when(organisationServiceMock.getOrganisationByOrgIdentifier(organisation.getOrganisationIdentifier())).thenReturn(organisation);
         when(professionalUserServiceMock.findProfessionalUserProfileByEmailAddress("testing@email.com")).thenReturn(professionalUser);
-        when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, "pui-user-manager")).thenReturn(true);
+        when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, TestConstants.PUI_USER_MANAGER)).thenReturn(true);
         when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
 
         doNothing().when(profExtUsrReqValidator).validateRequest(any(String.class), any(String.class), any(String.class));

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/ProfessionalExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/ProfessionalExternalUserControllerTest.java
@@ -91,11 +91,11 @@ public class ProfessionalExternalUserControllerTest {
         when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, "pui-user-manager")).thenReturn(true);
         when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
 
-        doNothing().when(profExtUsrReqValidator).validateRequest(any(String.class), any(String.class), any(String.class), any(String.class));
+        doNothing().when(profExtUsrReqValidator).validateRequest(any(String.class), any(String.class), any(String.class));
         doNothing().when(organisationIdentifierValidatorImpl).validate(any(Organisation.class), any(OrganisationStatus.class), any(String.class));
         doNothing().when(organisationCreationRequestValidator).validateOrganisationIdentifier(any(String.class));
 
-        ResponseEntity<?> actual = professionalExternalUserController.findUsersByOrganisation(organisation.getOrganisationIdentifier(), "true", null, "", null, null);
+        ResponseEntity<?> actual = professionalExternalUserController.findUsersByOrganisation(organisation.getOrganisationIdentifier(), "true", "", null, null);
         assertThat(actual).isNotNull();
         assertThat(actual.getStatusCode().value()).isEqualTo(expectedHttpStatus.value());
     }
@@ -131,11 +131,11 @@ public class ProfessionalExternalUserControllerTest {
         when(organisationIdentifierValidatorImpl.ifUserRoleExists(authorities, "pui-case-manager")).thenReturn(true);
         when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
 
-        doNothing().when(profExtUsrReqValidator).validateRequest(any(String.class), any(String.class), any(String.class), any(String.class));
+        doNothing().when(profExtUsrReqValidator).validateRequest(any(String.class), any(String.class), any(String.class));
         doNothing().when(organisationIdentifierValidatorImpl).validate(any(Organisation.class), any(OrganisationStatus.class), any(String.class));
         doNothing().when(organisationCreationRequestValidator).validateOrganisationIdentifier(any(String.class));
 
-        ResponseEntity<?> actual = professionalExternalUserController.findUsersByOrganisation(organisation.getOrganisationIdentifier(), "true", null, "Pending", null, null);
+        ResponseEntity<?> actual = professionalExternalUserController.findUsersByOrganisation(organisation.getOrganisationIdentifier(), "true", "Pending", null, null);
         assertThat(actual).isNotNull();
         assertThat(actual.getStatusCode().value()).isEqualTo(expectedHttpStatus.value());
     }

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/request/ProfessionalUserReqValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/request/ProfessionalUserReqValidatorTest.java
@@ -9,12 +9,12 @@ public class ProfessionalUserReqValidatorTest {
     @Test(expected = InvalidRequest.class)
     public void testValidateRequestAllNull() {
         profUserReqValidator
-                .validateRequest(null,null,null, null);
+                .validateRequest(null,null, null);
     }
 
     @Test
     public void testValidateRequestNoneNull() {
         profUserReqValidator
-                .validateRequest("ordId","true","some@email.com", "");
+                .validateRequest("ordId","true", "");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/entities/OrganisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/entities/OrganisationTest.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.reform.professionalapi.entities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_ORGANISATION_IDENTIFIER;
 import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.generateUniqueAlphanumericId;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_ORGANISATION_IDENTIFIER;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/generator/ProfessionalApiGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/generator/ProfessionalApiGeneratorTest.java
@@ -1,10 +1,9 @@
 package uk.gov.hmcts.reform.professionalapi.generator;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_ORGANISATION_IDENTIFIER;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_UUID;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.ORGANISATION_IDENTIFIER_FORMAT_REGEX;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_ORGANISATION_IDENTIFIER;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_UUID;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.ORGANISATION_IDENTIFIER_FORMAT_REGEX;
 
 import java.util.UUID;
 import org.junit.Test;

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/service/OrganisationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/service/OrganisationServiceImplTest.java
@@ -169,7 +169,8 @@ public class OrganisationServiceImplTest {
                 paymentAccountRepositoryMock,
                 dxAddressRepositoryMock,
                 contactInformationRepositoryMock,
-                userAttributeRepositoryMock, prdEnumRepositoryMock,
+                userAttributeRepositoryMock,
+                prdEnumRepositoryMock,
                 userAccountMapRepositoryMock,
                 userProfileFeignClient,
                 prdEnumServiceMock);

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/service/OrganisationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/service/OrganisationServiceImplTest.java
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_ORGANISATION_IDENTIFIER;
 import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.generateUniqueAlphanumericId;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_ORGANISATION_IDENTIFIER;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/service/OrganisationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/service/OrganisationServiceImplTest.java
@@ -171,8 +171,6 @@ public class OrganisationServiceImplTest {
                 paymentAccountRepositoryMock,
                 dxAddressRepositoryMock,
                 contactInformationRepositoryMock,
-                userAttributeRepositoryMock,
-                prdEnumRepositoryMock,
                 prdEnumRepositoryMock,
                 userAccountMapRepositoryMock,
                 userProfileFeignClient,

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/service/ProfessionalUserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/service/ProfessionalUserServiceTest.java
@@ -8,8 +8,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.LENGTH_OF_ORGANISATION_IDENTIFIER;
 import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGenerator.generateUniqueAlphanumericId;
+import static uk.gov.hmcts.reform.professionalapi.generator.ProfessionalApiGeneratorConstants.LENGTH_OF_ORGANISATION_IDENTIFIER;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-531

### Change description ###

splitting search user by email and search users by organisation endpoint into two separate endpoints, as per sonar issue and general maintainability

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
[x] I hope not
```
