### PR TITLE
DO NOT MERGE UNTIL CONFIRMED: RDCC-761 - amending FPLA endpoint and corresponding tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersStatusByEmailTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersStatusByEmailTest.java
@@ -22,6 +22,14 @@ import uk.gov.hmcts.reform.professionalapi.controller.request.NewUserCreationReq
 @Slf4j
 public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
 
+    /** Please note:
+     * The below tests were created for the Find User Status By Email endpoint - requested by FPLA team, re: Share A Case.
+     * The code and tests for this are complete, but FPLA has confirmed quite late that they are not ready to consume this endpoint.
+     * As a result they are not ready for their ITHC with us.
+     * HMCTS Reform and IA do not recommend having an active endpoint when there is no consumer for ITHC test.
+     * We have been advised to roll back the changes. This change will go to ITHC with FPLA in mid-January.
+     * Access to this endpoint will be blocked until FPLA are ready to consume.
+     * Any related tests will return 403 for the time being.*/
 
     @Test
     public void ac1_find_user_status_by_email_with_pui_user_manager_role_should_return_200() {
@@ -34,7 +42,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         professionalApiClient.getMultipleAuthHeadersExternal(puiCaseManager, userCreationRequest.getFirstName(), userCreationRequest.getLastName(), userCreationRequest.getEmail());
 
         professionalApiClient.addNewUserToAnOrganisation(orgId, hmctsAdmin, userCreationRequest, HttpStatus.CREATED);
-        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.OK, generateBearerTokenForPuiManager(), userCreationRequest.getEmail());
+        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, generateBearerTokenForPuiManager(), userCreationRequest.getEmail());
         assertThat(response.get("userIdentifier")).isNotNull();
 
     }
@@ -54,7 +62,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         // inviting user
         professionalApiClient.addNewUserToAnOrganisation(orgId, hmctsAdmin, userCreationRequest,  HttpStatus.CREATED);
         String email = userCreationRequest.getEmail().toUpperCase();
-        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.OK, generateBearerTokenForExternalUserRolesSpecified(userRoles),email);
+        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, generateBearerTokenForExternalUserRolesSpecified(userRoles),email);
         assertThat(response.get("userIdentifier")).isNotNull();
     }
 
@@ -68,7 +76,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         // inviting user
         professionalApiClient.addNewUserToAnOrganisation(orgId, hmctsAdmin, userCreationRequest, HttpStatus.CREATED);
         // find the status of the user
-        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.NOT_FOUND, generateBearerTokenForExternalUserRolesSpecified(userRoles), userCreationRequest.getEmail());
+        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, generateBearerTokenForExternalUserRolesSpecified(userRoles), userCreationRequest.getEmail());
         assertThat(response.get("userIdentifier")).isNull();
     }
 
@@ -90,7 +98,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         List<String> userRolesForToken = new ArrayList<>();
         userRolesForToken.add("pui-organisation-manager");
 
-        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.OK, generateBearerTokenForExternalUserRolesSpecified(userRolesForToken), userCreationRequest.getEmail());
+        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, generateBearerTokenForExternalUserRolesSpecified(userRolesForToken), userCreationRequest.getEmail());
         assertThat(response.get("userIdentifier")).isNotNull();
     }
 
@@ -114,7 +122,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         String email = randomAlphabetic(10) + "@usersearch.test".toLowerCase();
         RequestSpecification bearerTokenForCourtAdmin = professionalApiClient.getMultipleAuthHeadersExternal("caseworker-publiclaw-courtadmin", "externalFname", "externalLname", email);
 
-        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.OK, bearerTokenForCourtAdmin, userCreationRequest.getEmail());
+        Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, bearerTokenForCourtAdmin, userCreationRequest.getEmail());
         assertThat(response.get("userIdentifier")).isNotNull();
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersStatusByEmailTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersStatusByEmailTest.java
@@ -43,7 +43,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
 
         professionalApiClient.addNewUserToAnOrganisation(orgId, hmctsAdmin, userCreationRequest, HttpStatus.CREATED);
         Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, generateBearerTokenForPuiManager(), userCreationRequest.getEmail());
-        assertThat(response.get("userIdentifier")).isNotNull();
+        assertThat(response.get("userIdentifier")).isNull();
 
     }
 
@@ -63,7 +63,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         professionalApiClient.addNewUserToAnOrganisation(orgId, hmctsAdmin, userCreationRequest,  HttpStatus.CREATED);
         String email = userCreationRequest.getEmail().toUpperCase();
         Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, generateBearerTokenForExternalUserRolesSpecified(userRoles),email);
-        assertThat(response.get("userIdentifier")).isNotNull();
+        assertThat(response.get("userIdentifier")).isNull();
     }
 
     @Test
@@ -99,7 +99,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         userRolesForToken.add("pui-organisation-manager");
 
         Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, generateBearerTokenForExternalUserRolesSpecified(userRolesForToken), userCreationRequest.getEmail());
-        assertThat(response.get("userIdentifier")).isNotNull();
+        assertThat(response.get("userIdentifier")).isNull();
     }
 
     @Test
@@ -123,7 +123,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         RequestSpecification bearerTokenForCourtAdmin = professionalApiClient.getMultipleAuthHeadersExternal("caseworker-publiclaw-courtadmin", "externalFname", "externalLname", email);
 
         Map<String, Object> response = professionalApiClient.findUserStatusByEmail(HttpStatus.FORBIDDEN, bearerTokenForCourtAdmin, userCreationRequest.getEmail());
-        assertThat(response.get("userIdentifier")).isNotNull();
+        assertThat(response.get("userIdentifier")).isNull();
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/FindUserByEmailTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/FindUserByEmailTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.professionalapi.controller.response.ProfessionalUsersResponse;
@@ -75,9 +74,9 @@ public class FindUserByEmailTest extends AuthorizationEnabledIntegrationTest {
      * As a result they are not ready for their ITHC with us.
      * HMCTS Reform and IA do not recommend having an active endpoint when there is no consumer for ITHC test.
      * We have been advised to roll back the changes. This change will go to ITHC with FPLA in mid-January.
-     * It will remain commented out until FPLA are ready to consume. */
+     * Access to this endpoint will be blocked until FPLA are ready to consume.
+     * Any related tests will return 403 for the time being.*/
 
-    @Ignore
     @Test
     public void find_user_status_by_user_email_address_for_organisation_status_as_active() {
         userProfileCreateUserWireMock(HttpStatus.CREATED);
@@ -96,12 +95,11 @@ public class FindUserByEmailTest extends AuthorizationEnabledIntegrationTest {
         assertThat(userIdentifierResponse).isNotNull();
         Map<String, Object> response = professionalReferenceDataClient.findUserStatusByEmail(userEmail, puiUserManager);
 
-        assertThat(response.get("http_status")).isEqualTo("200 OK");
-        assertThat(response.get("userIdentifier")).isNotNull();
+        assertThat(response.get("http_status")).isEqualTo("403");
+        assertThat(response.get("userIdentifier")).isNull();
 
     }
 
-    @Ignore
     @Test
     public void should_throw_403_for_prd_admin_find_user_status_by_user_email_address_for_organisation_status_as_active() {
         userProfileCreateUserWireMock(HttpStatus.CREATED);
@@ -124,7 +122,6 @@ public class FindUserByEmailTest extends AuthorizationEnabledIntegrationTest {
 
     }
 
-    @Ignore
     @Test
     public void should_give_bad_request_for_invalid_email_to_find_user_status_by_user_email_address_for_organisation_status_as_active() {
         userProfileCreateUserWireMock(HttpStatus.CREATED);
@@ -142,7 +139,7 @@ public class FindUserByEmailTest extends AuthorizationEnabledIntegrationTest {
         String userIdentifierResponse = (String) newUserResponse.get("userIdentifier");
         Map<String, Object> response = professionalReferenceDataClient.findUserStatusByEmail("@@" + userEmail, puiUserManager);
 
-        assertThat(response.get("http_status")).isEqualTo("400");
+        assertThat(response.get("http_status")).isEqualTo("403");
 
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/FindUserByEmailTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/FindUserByEmailTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.professionalapi.controller.response.ProfessionalUsersResponse;
@@ -68,6 +69,15 @@ public class FindUserByEmailTest extends AuthorizationEnabledIntegrationTest {
         assertThat(response.get("http_status")).isEqualTo("404");
     }
 
+    /** Please note:
+     * The below tests were created for the Find User Status By Email endpoint - requested by FPLA team, re: Share A Case.
+     * The code and tests for this are complete, but FPLA has confirmed quite late that they are not ready to consume this endpoint.
+     * As a result they are not ready for their ITHC with us.
+     * HMCTS Reform and IA do not recommend having an active endpoint when there is no consumer for ITHC test.
+     * We have been advised to roll back the changes. This change will go to ITHC with FPLA in mid-January.
+     * It will remain commented out until FPLA are ready to consume. */
+
+    @Ignore
     @Test
     public void find_user_status_by_user_email_address_for_organisation_status_as_active() {
         userProfileCreateUserWireMock(HttpStatus.CREATED);
@@ -91,7 +101,7 @@ public class FindUserByEmailTest extends AuthorizationEnabledIntegrationTest {
 
     }
 
-
+    @Ignore
     @Test
     public void should_throw_403_for_prd_admin_find_user_status_by_user_email_address_for_organisation_status_as_active() {
         userProfileCreateUserWireMock(HttpStatus.CREATED);
@@ -114,6 +124,7 @@ public class FindUserByEmailTest extends AuthorizationEnabledIntegrationTest {
 
     }
 
+    @Ignore
     @Test
     public void should_give_bad_request_for_invalid_email_to_find_user_status_by_user_email_address_for_organisation_status_as_active() {
         userProfileCreateUserWireMock(HttpStatus.CREATED);

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
@@ -239,7 +239,6 @@ public class ProfessionalExternalUserController extends SuperController {
             value = "/users/accountId",
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
-    //@Secured({"pui-finance-manager", "pui-user-manager", "pui-organisation-manager", "pui-case-manager", "caseworker-publiclaw-courtadmin"})
     @Secured({"dummy-role"})
     public ResponseEntity<NewUserResponse> findUserStatusByEmail(
                                                     @ApiParam(name = "email", required = true) @RequestParam(value = "email") String email) {

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
@@ -29,13 +29,10 @@ import uk.gov.hmcts.reform.auth.checker.spring.serviceanduser.ServiceAndUserDeta
 import uk.gov.hmcts.reform.professionalapi.configuration.resolver.OrgId;
 import uk.gov.hmcts.reform.professionalapi.controller.SuperController;
 import uk.gov.hmcts.reform.professionalapi.controller.advice.ResourceNotFoundException;
-import uk.gov.hmcts.reform.professionalapi.controller.response.NewUserResponse;
 import uk.gov.hmcts.reform.professionalapi.controller.response.OrganisationResponse;
 import uk.gov.hmcts.reform.professionalapi.controller.response.ProfessionalUsersEntityResponse;
 import uk.gov.hmcts.reform.professionalapi.domain.ModifyUserRolesResponse;
 import uk.gov.hmcts.reform.professionalapi.domain.UserProfileUpdatedData;
-
-
 
 @RequestMapping(
         path = "refdata/external/v1/organisations",
@@ -197,8 +194,15 @@ public class ProfessionalExternalUserController extends SuperController {
 
     }
 
+    /** Please note:
+     * The development of the below endpoint was requested by FPLA team, re: Share A Case.
+     * The code and tests for this are complete, but FPLA has confirmed quite late that they are not ready to consume this endpoint.
+     * As a result they are not ready for their ITHC with us.
+     * HMCTS Reform and IA do not recommend having an active endpoint when there is no consumer for ITHC test.
+     * We have been advised to roll back the changes. This change will go to ITHC with FPLA in mid-January.
+     * It will remain commented out until FPLA are ready to consume. */
 
-    @ApiOperation(
+    /* @ApiOperation(
             value = "Retrieves the user status with the given email address if organisation is active",
             authorizations = {
                     @Authorization(value = "ServiceAuthorization"),
@@ -242,6 +246,6 @@ public class ProfessionalExternalUserController extends SuperController {
         //email is valid
         return professionalUserService.findUserStatusByEmailAddress(email.toLowerCase()
         );
-    }
+    } */
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/external/ProfessionalExternalUserController.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.reform.auth.checker.spring.serviceanduser.ServiceAndUserDeta
 import uk.gov.hmcts.reform.professionalapi.configuration.resolver.OrgId;
 import uk.gov.hmcts.reform.professionalapi.controller.SuperController;
 import uk.gov.hmcts.reform.professionalapi.controller.advice.ResourceNotFoundException;
+import uk.gov.hmcts.reform.professionalapi.controller.response.NewUserResponse;
 import uk.gov.hmcts.reform.professionalapi.controller.response.OrganisationResponse;
 import uk.gov.hmcts.reform.professionalapi.controller.response.ProfessionalUsersEntityResponse;
 import uk.gov.hmcts.reform.professionalapi.domain.ModifyUserRolesResponse;
@@ -200,9 +201,9 @@ public class ProfessionalExternalUserController extends SuperController {
      * As a result they are not ready for their ITHC with us.
      * HMCTS Reform and IA do not recommend having an active endpoint when there is no consumer for ITHC test.
      * We have been advised to roll back the changes. This change will go to ITHC with FPLA in mid-January.
-     * It will remain commented out until FPLA are ready to consume. */
+     * Access to this endpoint will be blocked until FPLA are ready to consume. */
 
-    /* @ApiOperation(
+    @ApiOperation(
             value = "Retrieves the user status with the given email address if organisation is active",
             authorizations = {
                     @Authorization(value = "ServiceAuthorization"),
@@ -238,7 +239,8 @@ public class ProfessionalExternalUserController extends SuperController {
             value = "/users/accountId",
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
-    @Secured({"pui-finance-manager", "pui-user-manager", "pui-organisation-manager", "pui-case-manager", "caseworker-publiclaw-courtadmin"})
+    //@Secured({"pui-finance-manager", "pui-user-manager", "pui-organisation-manager", "pui-case-manager", "caseworker-publiclaw-courtadmin"})
+    @Secured({"dummy-role"})
     public ResponseEntity<NewUserResponse> findUserStatusByEmail(
                                                     @ApiParam(name = "email", required = true) @RequestParam(value = "email") String email) {
 
@@ -246,6 +248,6 @@ public class ProfessionalExternalUserController extends SuperController {
         //email is valid
         return professionalUserService.findUserStatusByEmailAddress(email.toLowerCase()
         );
-    } */
+    }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-761

### Change description ###

The development of the findUserStatusByEmail endpoint was requested by FPLA team, re: Share A Case.
The code and tests for this are complete, but FPLA has confirmed quite late that they are not ready to consume this endpoint. As a result they are not ready for their ITHC with us. 
HMCTS Reform and IA do not recommend having an active endpoint when there is no consumer for ITHC test. 
We have been advised to roll back the changes. This change will go to ITHC with FPLA in mid-January. It will remain commented out until FPLA are ready to consume.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[✘] No
```
