### PR TITLE
RDCC-1931: Allow apostrophes in Email IDs at the point of User creation

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/CreateMinimalOrganisationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/CreateMinimalOrganisationTest.java
@@ -156,6 +156,25 @@ public class CreateMinimalOrganisationTest extends AuthorizationEnabledIntegrati
     }
 
     @Test
+    public void returns_200_when_email_has_apostrophe() {
+        OrganisationCreationRequest organisationCreationRequest = anOrganisationCreationRequest()
+                .name("some")
+                .superUser(aUserCreationRequest()
+                        .firstName("some-fname")
+                        .lastName("some-lname")
+                        .email("someone.o'name@test.com")
+                        .build())
+                .contactInformation(Arrays.asList(aContactInformationCreationRequest()
+                        .addressLine1("addressLine1").build())).build();
+
+        Map<String, Object> response =
+                professionalReferenceDataClient.createOrganisation(organisationCreationRequest);
+
+        assertThat(response.get("http_status")).isEqualTo("201 CREATED");
+
+    }
+
+    @Test
     public void returns_500_when_database_constraint_violated() {
         String organisationNameViolatingDatabaseMaxLengthConstraint = RandomStringUtils.random(256);
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/CreateNewUserWithRolesTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/professionalapi/CreateNewUserWithRolesTest.java
@@ -50,20 +50,6 @@ public class CreateNewUserWithRolesTest extends AuthorizationEnabledIntegrationT
     }
 
     @Test
-    public void post_request_adds_new_user_to_an_organisation() {
-        List<String> userRoles = new ArrayList<>();
-
-        userRoles.add("pui-user-manager");
-
-        userCreationRequest = aNewUserCreationRequest()
-                .firstName("someName")
-                .lastName("someLastName")
-                .email("somenewuser@email.com")
-                .roles(userRoles)
-                .build();
-    }
-
-    @Test
     public void post_request_adds_new_user_to_an_active_organisation() {
         userProfileCreateUserWireMock(HttpStatus.CREATED);
 

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/constants/ProfessionalApiConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/constants/ProfessionalApiConstants.java
@@ -10,7 +10,7 @@ public class ProfessionalApiConstants {
 
     public static final String EMAILREGEX = "^[a-zA-Z0-9_!#$%&’*+/=?`{|}~^-]+(?:\\.[a-zA-Z0-9_!#$%&’*+/=?`{|}~^-]+)"
             + "*@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$";
-    public static String EMAIL_REGEX = "^[A-Za-z0-9]+[\\w!#$%&’.*+/=?`{|}~^-]+(?:\\.[\\w!#$%&’*+/=?`{|}~^-]+)*@"
+    public static String EMAIL_REGEX = "^[A-Za-z0-9]+[\\w!#$%&'’.*+/=?`{|}~^-]+(?:\\.[\\w!#$%&’*+/=?`{|}~^-]+)*@"
             .concat("[A-Za-z0-9]+(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$");
 
     public static final int LENGTH_OF_UUID = 36;

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/constants/ProfessionalApiConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/constants/ProfessionalApiConstants.java
@@ -5,13 +5,8 @@ public class ProfessionalApiConstants {
     private ProfessionalApiConstants() {
     }
 
-    // There are various regex for same email format. We need to take up a task to make all email regex same in both
-    // PRD and UP
-
-    public static final String EMAILREGEX = "^[a-zA-Z0-9_!#$%&’*+/=?`{|}~^-]+(?:\\.[a-zA-Z0-9_!#$%&’*+/=?`{|}~^-]+)"
-            + "*@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$";
-    public static String EMAIL_REGEX = "^[A-Za-z0-9]+[\\w!#$%&'’.*+/=?`{|}~^-]+(?:\\.[\\w!#$%&’*+/=?`{|}~^-]+)*@"
-            .concat("[A-Za-z0-9]+(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$");
+    public static final String EMAIL_REGEX = "^[A-Za-z0-9]+[\\w!#$%&'’.*+/=?`{|}~^-]+(?:\\.[\\w!#$%&’*+/=?`{|}~^-]+)*@"
+            + "[A-Za-z0-9]+(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$";
 
     public static final int LENGTH_OF_UUID = 36;
     public static final int LENGTH_OF_ORGANISATION_IDENTIFIER = 7;

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/request/UserProfileCreationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/request/UserProfileCreationRequest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.professionalapi.controller.request;
 
-import static uk.gov.hmcts.reform.professionalapi.controller.constants.ProfessionalApiConstants.EMAILREGEX;
+import static uk.gov.hmcts.reform.professionalapi.controller.constants.ProfessionalApiConstants.EMAIL_REGEX;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -21,7 +21,7 @@ import uk.gov.hmcts.reform.professionalapi.domain.UserType;
 @Builder(builderMethodName = "anUserProfileCreationRequest")
 public class UserProfileCreationRequest  {
 
-    @Pattern(regexp = EMAILREGEX)
+    @Pattern(regexp = EMAIL_REGEX)
     private String email;
 
     @NotBlank

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/request/validator/OrganisationCreationRequestValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/request/validator/OrganisationCreationRequestValidatorTest.java
@@ -233,6 +233,7 @@ public class OrganisationCreationRequestValidatorTest {
         String[] validEmails = new String[]{
             "shreedhar.lomte@hmcts.net",
             "shreedhar@yahoo.com",
+            "ad'il@wahoo.com",
             "Email.100@yahoo.com",
             "email111@email.com",
             "email.100@email.com.au",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-1931

### Change description ###

Email Validation: Remove validation related to entry of apostrophes as part of the email IDs of users at the point of user creation

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
