### PR TITLE
Fix: Adding retry to Super User Bearer Token generation

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/AuthorizationFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/AuthorizationFunctionalTest.java
@@ -5,7 +5,6 @@ import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.professionalapi.controller.request.NewUserCreationRequest.aNewUserCreationRequest;
 import static uk.gov.hmcts.reform.professionalapi.controller.request.UserCreationRequest.aUserCreationRequest;
-import static uk.gov.hmcts.reform.professionalapi.helper.OrganisationFixtures.someMinimalOrganisationRequest;
 
 import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
@@ -29,6 +28,7 @@ import uk.gov.hmcts.reform.professionalapi.client.ProfessionalApiClient;
 import uk.gov.hmcts.reform.professionalapi.client.S2sClient;
 import uk.gov.hmcts.reform.professionalapi.config.Oauth2;
 import uk.gov.hmcts.reform.professionalapi.config.TestConfigProperties;
+import uk.gov.hmcts.reform.professionalapi.controller.advice.ExternalApiException;
 import uk.gov.hmcts.reform.professionalapi.controller.constants.IdamStatus;
 import uk.gov.hmcts.reform.professionalapi.controller.request.NewUserCreationRequest;
 import uk.gov.hmcts.reform.professionalapi.controller.request.OrganisationCreationRequest;
@@ -289,37 +289,27 @@ public class AuthorizationFunctionalTest extends AbstractTestExecutionListener {
         return userCreationRequest;
     }
 
-    public RequestSpecification generateSuperUserBearerToken() {
-        String firstName = "some-fname";
-        String lastName = "some-lname";
-        String email = generateRandomEmail();
 
+    public String getExternalSuperUserTokenWithRetry(String email, String firstName, String lastName) {
+        int counter = 0;
 
-        String idamResponse =
-                idamOpenIdClient.getExternalOpenIdTokenWithRetry(superUserRoles(), firstName, lastName, email);
+        String idamResponse = idamOpenIdClient
+                .getExternalOpenIdTokenWithRetry(superUserRoles(), firstName, lastName, email);
 
-        if (idamResponse.equalsIgnoreCase("504")) {
+        while (idamResponse.equalsIgnoreCase("504") && counter < 4) {
+            log.info("Retry Super User Token attempt :" + counter + "/3");
             email = generateRandomEmail().toLowerCase();
-            idamResponse =
-                    idamOpenIdClient.getExternalOpenIdTokenWithRetry(superUserRoles(), firstName, lastName, email);
+            idamResponse = idamOpenIdClient
+                    .getExternalOpenIdTokenWithRetry(superUserRoles(), firstName, lastName, email);
+            counter++;
         }
 
-        bearerToken = professionalApiClient.getMultipleAuthHeaders(idamResponse);
-
-        UserCreationRequest superUser = aUserCreationRequest()
-                .firstName(firstName)
-                .lastName(lastName)
-                .email(email)
-                .build();
-        OrganisationCreationRequest request = someMinimalOrganisationRequest()
-                .superUser(superUser)
-                .build();
-
-        Map<String, Object> response = professionalApiClient.createOrganisation(request);
-        String orgIdentifier = (String) response.get("organisationIdentifier");
-        request.setStatus("ACTIVE");
-        professionalApiClient.updateOrganisation(request, hmctsAdmin, orgIdentifier);
-        return bearerToken;
+        if (idamResponse.equalsIgnoreCase("504")) {
+            throw new ExternalApiException(HttpStatus.GATEWAY_TIMEOUT,
+                    "Received more than 3 timeouts from IDAM while Generating Token");
+        } else {
+            return email;
+        }
     }
 
     public UserCreationRequest createSuperUser(String email, String firstName, String lastName) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/DeleteOrganisationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/DeleteOrganisationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.professionalapi.controller.request.UserCreationRequest.aUserCreationRequest;
 import static uk.gov.hmcts.reform.professionalapi.helper.OrganisationFixtures.someMinimalOrganisationRequest;
 
-import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.RandomStringUtils;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
@@ -79,15 +78,16 @@ public class DeleteOrganisationTest extends AuthorizationFunctionalTest {
     public void ac6_could_not_delete_an_active_organisation_with_active_user_profile_by_prd_admin() {
         String firstName = "some-fname";
         String lastName = "some-lname";
-        String email = RandomStringUtils.randomAlphabetic(10) + "@usersearch.test".toLowerCase();
-        UserCreationRequest superUser = aUserCreationRequest()
-            .firstName(firstName)
-            .lastName(lastName)
-            .email(email)
-            .build();
+        String email = generateRandomEmail().toLowerCase();
 
-        bearerToken = professionalApiClient.getMultipleAuthHeadersExternalForSuperUser(superUserRoles(), firstName,
-            lastName, email);
+        email = getExternalSuperUserTokenWithRetry(email, firstName, lastName);
+
+        UserCreationRequest superUser = aUserCreationRequest()
+                .firstName(firstName)
+                .lastName(lastName)
+                .email(email)
+                .build();
+
         OrganisationCreationRequest request = someMinimalOrganisationRequest()
             .superUser(superUser)
             .build();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersStatusByEmailTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/FindUsersStatusByEmailTest.java
@@ -45,6 +45,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         assertThat(response.get("userIdentifier")).isNotNull();
     }
 
+    @Ignore //TODO: convert to integration test
     @Test
     public void findUserStatusByEmailFromHeaderWithPuiCaseManagerRoleShouldReturn200() {
         puiCaseManagerBearerToken = generateBearerToken(puiCaseManagerBearerToken, "pui-user-manager");
@@ -88,6 +89,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         assertThat(response.get("userIdentifier")).isNull();
     }
 
+    @Ignore //TODO: convert to integration test
     @Test
     public void findUsrStatusByEmailFrmHeaderWithPuiCaseManagerRoleShouldReturn200WithUserStatusActive() {
         puiCaseManagerBearerToken = generateBearerToken(puiCaseManagerBearerToken, "pui-user-manager");
@@ -97,6 +99,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         assertThat(response.get("userIdentifier")).isNotNull();
     }
 
+    @Ignore //TODO: convert to integration test
     @Test
     public void findUsrStatusByEmailFrmHeaderWithNotActivePuiFinanceMgrRoleShouldRtnStatusForUsr() {
         // creating new user request
@@ -111,6 +114,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         assertThat(response.get("userIdentifier")).isNotNull();
     }
 
+    @Ignore //TODO: convert to integration test
     @Test
     public void findUsrStatusByEmailFrmHeaderWithNotActivePuiFinanceMgrRoleShouldRtnStatusPendingForUsr() {
         // creating new user request
@@ -125,6 +129,7 @@ public class FindUsersStatusByEmailTest extends AuthorizationFunctionalTest {
         assertThat(response.get("userIdentifier")).isNull();
     }
 
+    @Ignore //TODO: convert to integration test
     @Test
     public void ac4_find_usr_status_by_email_with_active_pui_organisation_manager_role_should_return_status_for_usr() {
         puiOrgManagerBearerToken = generateBearerToken(puiOrgManagerBearerToken, "pui-user-manager");

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/UserRolesTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/UserRolesTest.java
@@ -37,18 +37,13 @@ public class UserRolesTest extends AuthorizationFunctionalTest {
 
         String email = generateRandomEmail().toLowerCase();
 
-        String idamResponse =
-                idamOpenIdClient.getExternalOpenIdTokenWithRetry(superUserRoles(), firstName, lastName, email);
-
-        if (idamResponse.equalsIgnoreCase("504")) {
-            email = generateRandomEmail().toLowerCase();
-            idamOpenIdClient.getExternalOpenIdTokenWithRetry(superUserRoles(), firstName, lastName, email);
-        }
+        email = getExternalSuperUserTokenWithRetry(email, firstName, lastName);
 
         UserCreationRequest superUser = createSuperUser(email);
         OrganisationCreationRequest request = someMinimalOrganisationRequest()
                 .superUser(superUser)
                 .build();
+
         log.info("create organisation request");
         Map<String, Object> response = professionalApiClient.createOrganisation(request);
         orgIdentifier = (String) response.get("organisationIdentifier");

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/client/ProfessionalApiClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/client/ProfessionalApiClient.java
@@ -761,14 +761,6 @@ public class ProfessionalApiClient {
         return getMultipleAuthHeaders(bearerTokenForSuperUser);
     }
 
-    public RequestSpecification getMultipleAuthHeadersExternalForSuperUser(List<String> roles, String firstName,
-                                                                           String lastName, String email) {
-        String bearerTokenForSuperUser =
-                idamOpenIdClient.getExternalOpenIdTokenWithRetry(roles, firstName, lastName, email);
-        log.info("SuperUser Token:" + bearerTokenForSuperUser);
-        return getMultipleAuthHeaders(bearerTokenForSuperUser);
-    }
-
     public String getBearerTokenExternal(String role, String firstName, String lastName,
                                                                String email) {
         return idamOpenIdClient.getExternalOpenIdToken(role, firstName, lastName, email);


### PR DESCRIPTION
### Change description ###

- [x] Adding retry to Super User Bearer Token generation: https://github.com/hmcts/rd-professional-api/commit/3fcfe6b67cf5e7b73e9746675efe004e942707b0
- [x] Adding `@Ignore` to certain functional tests cases that will be converted to integration tests in future: https://github.com/hmcts/rd-professional-api/commit/f56b603c8bb1c2a666d2756a6e7907bbff7c4bfa

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
