### PR TITLE
fix: adding '@Ignore' to functional tests to be converted

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/AddNewUserTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/AddNewUserTest.java
@@ -81,6 +81,7 @@ public class AddNewUserTest extends AuthorizationFunctionalTest {
         assertThat((String) newUserResponse.get("errorDescription")).contains("409 User already exists");
     }
 
+    @Ignore //TODO: convert to integration test once RDCC-2050 is completed
     @Test
     public void add_new_user_to_organisation_by_super_user() {
         List<String> userRoles = new ArrayList<>();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/DeleteOrganisationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/DeleteOrganisationTest.java
@@ -74,6 +74,7 @@ public class DeleteOrganisationTest extends AuthorizationFunctionalTest {
     }
 
 
+    @Ignore //TODO: convert to integration test once RDCC-2050 is completed
     @Test
     public void ac6_could_not_delete_an_active_organisation_with_active_user_profile_by_prd_admin() {
         String firstName = "some-fname";

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/UserRolesTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/UserRolesTest.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
 import net.thucydides.core.annotations.WithTag;
 import net.thucydides.core.annotations.WithTags;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,7 @@ public class UserRolesTest extends AuthorizationFunctionalTest {
     private String firstName = "some-fname";
     private String lastName = "some-lname";
 
+    @Ignore //TODO: convert to integration test once RDCC-2050 is completed
     @Test
     public void rdcc_720_and_1387_ac1_super_user_can_have_caa_roles_fpla_or_iac_roles_not_puiCaa_caseworkerCaa() {
 


### PR DESCRIPTION
### Change description ###

adding '@Ignore' to functional tests to be converted

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
