### PR TITLE
RDCC-2819: refactoring getUserEmail() to prevent NPE being thrown

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/ProfessionalExternalUserFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/ProfessionalExternalUserFunctionalTest.java
@@ -62,6 +62,7 @@ public class ProfessionalExternalUserFunctionalTest extends AuthorizationFunctio
         setUpOrgTestData();
         setUpUserBearerTokens();
         inviteUserScenarios();
+        retrieveOrganisationPbaScenarios();
         findUsersByOrganisationScenarios();
         findOrganisationScenarios();
         findActiveOrganisationScenarios();
@@ -445,5 +446,18 @@ public class ProfessionalExternalUserFunctionalTest extends AuthorizationFunctio
         Map<String, Object> mfaStatusResponse = professionalApiClient.findMFAByUserId(OK, superUserId);
         assertThat(mfaStatusResponse.get("mfa")).isEqualTo("EMAIL");
         log.info("findMFAByUserIDShouldBeSuccess :: END");
+    }
+
+    public void retrieveOrganisationPbaScenarios() {
+        findOrganisationPbaWithoutEmailByExternalUserShouldBeBadRequest();
+    }
+
+    public void findOrganisationPbaWithoutEmailByExternalUserShouldBeBadRequest() {
+        log.info("findOrganisationPbaWithoutEmailByExternalUserShouldBeBadRequest :: STARTED");
+
+        professionalApiClient.retrievePaymentAccountsWithoutEmailForExternal(
+                professionalApiClient.getMultipleAuthHeaders(pumBearerToken));
+
+        log.info("findOrganisationPbaWithoutEmailByExternalUserShouldBeBadRequest :: END");
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/ProfessionalInternalUserFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/ProfessionalInternalUserFunctionalTest.java
@@ -112,6 +112,7 @@ public class ProfessionalInternalUserFunctionalTest extends AuthorizationFunctio
     public void retrieveOrganisationPbaScenarios() {
         findOrganisationPbaWithEmailByInternalUserShouldBeSuccess();
         findOrganisationPbaWithEmailThroughHeaderByInternalUserShouldBeSuccess();
+        findOrganisationPbaWithoutEmailByInternalUserShouldBeBadRequest();
     }
 
     public void modifyUserRolesScenarios() {
@@ -249,6 +250,12 @@ public class ProfessionalInternalUserFunctionalTest extends AuthorizationFunctio
                 superUserEmail.toLowerCase(), hmctsAdmin);
         validatePbaResponse(orgResponse);
         log.info("findOrganisationPbaWithEmailByInternalUserShouldBeSuccess :: END");
+    }
+
+    public void findOrganisationPbaWithoutEmailByInternalUserShouldBeBadRequest() {
+        log.info("findOrganisationPbaWithoutEmailByInternalUserShouldBeBadRequest :: STARTED");
+        professionalApiClient.retrievePaymentAccountsWithoutEmailForInternal();
+        log.info("findOrganisationPbaWithoutEmailByInternalUserShouldBeBadRequest :: END");
     }
 
     public void findOrganisationPbaWithEmailThroughHeaderByInternalUserShouldBeSuccess() {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/client/ProfessionalApiClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/professionalapi/client/ProfessionalApiClient.java
@@ -33,6 +33,7 @@ import uk.gov.hmcts.reform.professionalapi.idam.IdamOpenIdClient;
 
 import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
@@ -326,6 +327,35 @@ public class ProfessionalApiClient {
             .statusCode(OK.value());
 
         return response.body().as(Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void retrievePaymentAccountsWithoutEmailForInternal() {
+        Response response = getMultipleAuthHeadersInternal()
+                .get("/refdata/internal/v1/organisations/pbas")
+                .andReturn();
+
+        log.info("{}:: Retrieve organisation (Internal) response: {}", loggingComponentName, response.statusCode());
+
+        response.then()
+                .assertThat()
+                .statusCode(BAD_REQUEST.value())
+                .body("errorDescription", equalTo("No User Email provided via header or param"));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public void retrievePaymentAccountsWithoutEmailForExternal(RequestSpecification requestSpecification) {
+        Response response = requestSpecification
+                .get("refdata/external/v1/organisations/pbas")
+                .andReturn();
+
+        log.info("{}:: Retrieve organisation (External) response: {}", loggingComponentName, response.statusCode());
+
+        response.then()
+                .assertThat()
+                .statusCode(BAD_REQUEST.value())
+                .body("errorDescription", equalTo("No User Email provided via header or param"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/SuperController.java
@@ -138,8 +138,8 @@ public abstract class SuperController {
     private static final String IDAM_ERROR_MESSAGE = "{}:: Idam register user failed with status code : %s";
 
 
-    protected ResponseEntity<OrganisationResponse>
-        createOrganisationFrom(OrganisationCreationRequest organisationCreationRequest) {
+    protected ResponseEntity<OrganisationResponse> createOrganisationFrom(
+            OrganisationCreationRequest organisationCreationRequest) {
 
         organisationCreationRequestValidator.validate(organisationCreationRequest);
 
@@ -365,9 +365,8 @@ public abstract class SuperController {
                 .body(responseBody);
     }
 
-    private ProfessionalUser
-        validateInviteUserRequestAndCreateNewUserObject(NewUserCreationRequest newUserCreationRequest,
-                                                        String organisationIdentifier, List<String> roles) {
+    private ProfessionalUser validateInviteUserRequestAndCreateNewUserObject(
+            NewUserCreationRequest newUserCreationRequest, String organisationIdentifier, List<String> roles) {
 
         validateNewUserCreationRequestForMandatoryFields(newUserCreationRequest);
         final Organisation existingOrganisation = checkOrganisationIsActive(removeEmptySpaces(organisationIdentifier));
@@ -410,7 +409,7 @@ public abstract class SuperController {
 
         userProfileUpdatedData = userProfileUpdateRequestValidator.validateRequest(userProfileUpdatedData);
 
-        return  professionalUserService.modifyRolesForUser(userProfileUpdatedData, userId, origin);
+        return professionalUserService.modifyRolesForUser(userProfileUpdatedData, userId, origin);
     }
 
     public void checkUserAlreadyExist(String userEmail) {
@@ -426,15 +425,25 @@ public abstract class SuperController {
         return existingOrganisation;
     }
 
-    public  String getUserEmail(String email) {
+    public String getUserEmail(String email) {
         String userEmail = null;
         ServletRequestAttributes servletRequestAttributes =
                 ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes());
 
         if (nonNull(servletRequestAttributes)) {
             HttpServletRequest request = servletRequestAttributes.getRequest();
-            userEmail = request.getHeader("UserEmail") != null ? request.getHeader("UserEmail") : email;
+
+            if (nonNull(request.getHeader("UserEmail"))) {
+                userEmail = request.getHeader("UserEmail");
+
+            } else if (nonNull(email)) {
+                userEmail = email;
+
+            } else {
+                throw new InvalidRequest("No User Email provided via header or param");
+            }
         }
+
         return userEmail;
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-2819

### Change description ###

_PRD: Retrieve PBAs by Email without passing an Email throws `NPE`_

Refactored `getUserEmail()` to prevent `NPE` being thrown

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
