### PR TITLE
RDCC-3799: upgrading log4j to '2.16.0'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ def versions = [
         launchDarklySdk    : "5.2.2",
         junit           : '5.8.1',
         junitPlatform   : '1.8.1',
-        log4j              : '2.15.0'
+        log4j              : '2.16.0'
 ]
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-3799

### Change description ###

upgrading log4j to '2.16.0'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
