### PR TITLE
Fix: Upgrading log4j to fix CVE-2021-45105

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ def versions = [
         launchDarklySdk : "5.2.2",
         junit           : '5.8.1',
         junitPlatform   : '1.8.1',
-        log4j           : '2.16.0'
+        log4j           : '2.17.0'
 ]
 
 


### PR DESCRIPTION
### Change description ###

Upgrading log4j to fix CVE-2021-45105

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
