### PR TITLE
feat: RDCC-3833 Added address ID, UPRN and created date to the get response of internal and external organisation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("net.serenity-bdd:serenity-gradle-plugin:2.3.6")
+        classpath("net.serenity-bdd:serenity-gradle-plugin:2.4.34")
     }
 }
 
@@ -305,7 +305,7 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.0.2'
 
-    implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.5'
+    implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.0.5'
     implementation group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
     implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'
     implementation(group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0') {
@@ -373,12 +373,12 @@ dependencies {
     testRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-engine', version: versions.junitPlatform
 
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.4.6'
-    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.2'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.2.0'
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.3.3'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
 
     testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '4.0.0'
-    testImplementation group: 'io.rest-assured', name: 'rest-assured-common', version: '4.2.0'
+    testImplementation group: 'io.rest-assured', name: 'rest-assured-common', version: '4.4.0'
 
     testImplementation group: 'com.h2database', name: 'h2'
 
@@ -402,14 +402,14 @@ dependencies {
     }
 
     testImplementation group: 'net.serenity-bdd', name: 'serenity-core', version: '3.0.2'
-    testImplementation group: 'net.serenity-bdd', name: 'serenity-spring', version: '3.0.2'
+    testImplementation group: 'net.serenity-bdd', name: 'serenity-spring', version: '3.1.15'
     testImplementation group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
-    testImplementation 'io.github.openfeign:feign-jackson:11.2'
+    testImplementation 'io.github.openfeign:feign-jackson:11.7'
     testImplementation group: 'com.github.mifmif', name: 'generex', version: '1.0.2'
 
-    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:3.0.2'
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:3.1.0'
 
-    testImplementation group: 'org.codehaus.groovy', name: 'groovy', version: '2.5.15'
+    testImplementation group: 'org.codehaus.groovy', name: 'groovy', version: '3.0.9'
     testImplementation group: 'org.codehaus.groovy', name: 'groovy-xml', version: '2.5.15'
     testImplementation group: 'org.codehaus.groovy', name: 'groovy-json', version: '2.5.15'
     testCompile 'com.github.hmcts:fortify-client:1.2.0:all'
@@ -419,7 +419,7 @@ dependencies {
     contractTestRuntimeOnly group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version
     contractTestRuntimeOnly group: 'au.com.dius.pact.consumer', name: 'java8', version: versions.pact_version
 
-    contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5', version: '4.2.14'
+    contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5', version: '4.3.2'
     contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5spring', version: '4.2.14'
 
     functionalTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.8.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,7 +7,7 @@
         <packageUrl regex="true">^pkg:maven*.*$</packageUrl>
         <cve>CVE-2018-1258</cve>
     </suppress>
-    <suppress until="2022-01-05">
+    <suppress until="2022-07-05">
         <notes><![CDATA[
    file name: oauth2-oidc-sdk-7.1.1.jar
    ]]></notes>

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/response/ContactInformationResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/response/ContactInformationResponse.java
@@ -5,10 +5,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.professionalapi.domain.ContactInformation;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 @NoArgsConstructor
 @Getter
 public class ContactInformationResponse {
 
+    @JsonProperty
+    protected UUID addressId;
+    @JsonProperty
+    protected String uprn;
+    @JsonProperty
+    protected LocalDateTime created;
     @JsonProperty
     protected String addressLine1;
     @JsonProperty
@@ -25,6 +34,9 @@ public class ContactInformationResponse {
     protected String postCode;
 
     public ContactInformationResponse(ContactInformation contactInfo) {
+        this.addressId = contactInfo.getId();
+        this.uprn = "";
+        this.created = contactInfo.getCreated();
         this.addressLine1 = contactInfo.getAddressLine1();
         this.addressLine2 = contactInfo.getAddressLine2();
         this.addressLine3 = contactInfo.getAddressLine3();

--- a/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/response/ContactInformationResponseWithDxAddress.java
+++ b/src/main/java/uk/gov/hmcts/reform/professionalapi/controller/response/ContactInformationResponseWithDxAddress.java
@@ -16,6 +16,9 @@ public class ContactInformationResponseWithDxAddress extends ContactInformationR
     private final List<DxAddressResponse> dxAddress;
 
     public ContactInformationResponseWithDxAddress(ContactInformation contactInfo) {
+        this.addressId = contactInfo.getId();
+        this.uprn = "";
+        this.created = contactInfo.getCreated();
         this.addressLine1 = contactInfo.getAddressLine1();
         this.addressLine2 = contactInfo.getAddressLine2();
         this.addressLine3 = contactInfo.getAddressLine3();

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/response/ContactInformationResponseWithDxAddressTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/controller/response/ContactInformationResponseWithDxAddressTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.professionalapi.controller.response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,6 +22,7 @@ class ContactInformationResponseWithDxAddressTest {
     final String expectCounty = "City of London";
     final String expectCountry = "England";
     final String expectTownCity = "London";
+    final LocalDateTime created = LocalDateTime.now();
 
     @Test
     void testGetContactInformationResponse() {
@@ -34,6 +36,7 @@ class ContactInformationResponseWithDxAddressTest {
         contactInformation.setCounty(expectCounty);
         contactInformation.setCountry(expectCountry);
         contactInformation.setTownCity(expectTownCity);
+        contactInformation.setCreated(created);
         contactInformation.setDxAddresses(dxAddressList);
 
         ContactInformationResponseWithDxAddress sut = new ContactInformationResponseWithDxAddress(contactInformation);
@@ -46,6 +49,7 @@ class ContactInformationResponseWithDxAddressTest {
         assertThat(sut.getCountry()).isEqualTo(expectCountry);
         assertThat(sut.getTownCity()).isEqualTo(expectTownCity);
         assertThat(sut.getDxAddress()).isNotEmpty();
+        assertThat(sut.getCreated()).isEqualTo(created);
     }
 
     @Test
@@ -58,6 +62,7 @@ class ContactInformationResponseWithDxAddressTest {
         contactInformation.setCounty(expectCounty);
         contactInformation.setCountry(expectCountry);
         contactInformation.setTownCity(expectTownCity);
+        contactInformation.setCreated(created);
 
         ContactInformationResponseWithDxAddress sut = new ContactInformationResponseWithDxAddress(contactInformation);
 
@@ -68,6 +73,7 @@ class ContactInformationResponseWithDxAddressTest {
         assertThat(sut.getCounty()).isEqualTo(expectCounty);
         assertThat(sut.getCountry()).isEqualTo(expectCountry);
         assertThat(sut.getTownCity()).isEqualTo(expectTownCity);
+        assertThat(sut.getCreated()).isEqualTo(created);
         assertThat(sut.getDxAddress()).isEmpty();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/professionalapi/service/impl/OrganisationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/professionalapi/service/impl/OrganisationServiceImplTest.java
@@ -1107,5 +1107,25 @@ class OrganisationServiceImplTest {
         verify(professionalUserServiceMock, times(1)).checkUserStatusIsActiveByUserId(any());
     }
 
+    @Test
+    void test_sortContactInfoByCreatedDateAsc() {
+        ContactInformation contactInformation = new ContactInformation();
+        contactInformation.setCountry("TestCountry");
+        contactInformation.setCreated(LocalDateTime.now());
+
+        ContactInformation contactInformation1 = new ContactInformation();
+        contactInformation1.setCountry("TestAnotherCountry");
+        contactInformation1.setCreated(LocalDateTime.now());
+        organisation.setContactInformations(List.of(contactInformation1, contactInformation));
+        organisation.setStatus(OrganisationStatus.ACTIVE);
+        when(organisationRepository.findByOrganisationIdentifier(any())).thenReturn(organisation);
+
+        var organisationEntityResponse =
+                sut.retrieveOrganisation(organisationIdentifier, false);
+
+        assertEquals("TestCountry", organisationEntityResponse.getContactInformation().get(0).getCountry());
+        assertEquals("TestAnotherCountry",
+                organisationEntityResponse.getContactInformation().get(1).getCountry());
+    }
 
 }


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDCC-3833

### Change description ###

- Added address ID, UPRN and created date to the get response of internal and external organisation
- Sorted the contact info by created date ASC for get response of organisation by organisation id


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
