### PR TITLE
fix: Bump base java helm chart to 3.7.1

### DIFF
--- a/charts/rd-professional-api/Chart.yaml
+++ b/charts/rd-professional-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: Reference Data Team
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.1
     repository: '@hmctspublic'


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDCC-4056

### Change description ###

fix: Bump base java helm chart to 3.7.1 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```