### PR TITLE
RDCC-4263: Fixing CVE-2020-36518

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,6 @@ dependencies {
 
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.1'
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'
     implementation 'com.github.hmcts:idam-java-client:2.0.1'
     implementation "org.springframework.boot:spring-boot-starter-oauth2-client"

--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,7 @@ dependencies {
 
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.3'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.1'
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'
     implementation 'com.github.hmcts:idam-java-client:2.0.1'
     implementation "org.springframework.boot:spring-boot-starter-oauth2-client"

--- a/build.gradle
+++ b/build.gradle
@@ -322,7 +322,7 @@ dependencies {
     implementation 'com.github.hmcts:properties-volume-spring-boot-starter:0.1.0'
     implementation 'com.github.hmcts:service-auth-provider-java-client:4.0.3'
 
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.3'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.1'
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'

--- a/build.gradle
+++ b/build.gradle
@@ -477,6 +477,12 @@ dependencyManagement {
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'
         }
+
+        dependencySet(group: 'com.fasterxml.jackson.core', version: '2.13.2') {
+            entry 'jackson-databind'
+            entry 'jackson-core'
+            entry 'jackson-annotations'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,7 @@ dependencies {
 
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.3'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.11.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2'
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'
     implementation 'com.github.hmcts:idam-java-client:2.0.1'
     implementation "org.springframework.boot:spring-boot-starter-oauth2-client"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-4263

### Change description ###

Upgrading `jackson-core` to `2.13.2` version to fix `CVE-2020-36518`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
