### PR TITLE
CVE fix: Bumped spring dependencies version to 5.3.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ def versions = [
         launchDarklySdk : "5.8.1",
         junit           : '5.8.1',
         junitPlatform   : '1.8.1',
-        log4j           : '2.17.1'
+        log4j           : '2.17.1',
+        springVersion   : '5.3.20'
 ]
 
 
@@ -307,21 +308,21 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
     implementation group: 'org.springframework.retry', name: 'spring-retry', version: '1.3.1'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
-    implementation group: 'org.springframework', name: 'spring-core', version: '5.3.19'
     implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.6.1'
-    implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.18'
 
-    implementation group: 'org.springframework', name: 'spring-aop', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-aspects', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-context', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-context-support', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-expression', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-jcl', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-orm', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-tx', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-web', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-webmvc', version: '5.3.18'
+    implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-beans', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-aop', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-aspects', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-context', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-context-support', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-expression', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-jcl', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-jdbc', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-orm', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-tx', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-web', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-webmvc', version: versions.springVersion
 
     implementation group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
     implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-4707


### Change description ###
Bumped spring dependencies version to 5.3.20


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
