### PR TITLE
RDCC-5534: Upgrading `launchdarkly-java-server-sdk` & `snakeyaml`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def versions = [
         springBoot      : '2.6.6',
         springfoxSwagger: '2.9.2',
         pact_version    : '4.1.7',
-        launchDarklySdk : "5.9.3",
+        launchDarklySdk : "5.10.2",
         junit           : '5.8.1',
         junitPlatform   : '1.8.1',
         log4j           : '2.17.1',
@@ -357,7 +357,7 @@ dependencies {
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '7.10.0'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 
-    implementation group: 'org.yaml', name: 'snakeyaml', version: '1.31'
+    implementation group: 'org.yaml', name: 'snakeyaml', version: '1.33'
 
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
     implementation group: 'javax.el', name: 'javax.el-api', version: '3.0.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,12 +19,4 @@
      ]]></notes>
         <cve>CVE-2022-34305</cve>
     </suppress>
-    <suppress>
-        <notes>Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk</notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <cve>CVE-2022-25857</cve>
-        <cve>CVE-2022-38749</cve>
-        <cve>CVE-2022-38750</cve>
-        <cve>CVE-2022-38751</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5534

### Change description ###

Upgrading `launchdarkly-java-server-sdk` & `snakeyaml` to fix CVE-2022-38752

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
