### PR TITLE
RDCC-6130: Adding suppressions for `CVE-2022-3064` & `CVE-2021-4235`

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,4 +20,9 @@
         <cve>CVE-2022-34305</cve>
         <cve>CVE-2021-37533</cve>
     </suppress>
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2021-4235</cve>
+        <cve>CVE-2022-3064</cve>
+    </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -25,4 +25,10 @@
         <cve>CVE-2021-4235</cve>
         <cve>CVE-2022-3064</cve>
     </suppress>
+        <suppress>
+        <notes>
+            False positive - https://github.com/jeremylong/DependencyCheck/issues/5213
+        </notes>
+        <cve>CVE-2021-4277</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-6130

### Change description ###

Adding suppressions for `CVE-2022-3064` & `CVE-2021-4235`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
